### PR TITLE
Duplicate ids can break multiload

### DIFF
--- a/pyravendb/store/document_session.py
+++ b/pyravendb/store/document_session.py
@@ -117,7 +117,7 @@ class documentsession(object):
                     if results[i] is None:
                         self._known_missing_ids.add(ids_of_not_existing_object[i])
                         continue
-                    self._convert_and_save_entity(keys[i], results[i], object_type, nested_object_types)
+                    self._convert_and_save_entity(ids_of_not_existing_object[i], results[i], object_type, nested_object_types)
                 self.save_includes(response_includes)
         return [None if key in self._known_missing_ids else self._entities_by_key[
             key] if key in self._entities_by_key else None for key in keys]

--- a/pyravendb/store/document_session.py
+++ b/pyravendb/store/document_session.py
@@ -3,6 +3,7 @@ from pyravendb.custom_exceptions import exceptions
 from pyravendb.store.session_query import Query
 from pyravendb.d_commands import commands_data
 from pyravendb.tools.utils import Utils
+from collections import OrderedDict
 
 
 class _SaveChangesData(object):
@@ -102,7 +103,9 @@ class documentsession(object):
             ids_of_not_existing_object = [key for key in keys if
                                           key not in self._entities_by_key]
 
-        ids_of_not_existing_object = [key for key in ids_of_not_existing_object if key not in self._known_missing_ids]
+        # We need to remove duplicate ids in here for our index lookup strategy below to work
+        # because RavenDB is smart enough to not return duplicate results
+        ids_of_not_existing_object = list(OrderedDict.fromkeys([key for key in ids_of_not_existing_object if key not in self._known_missing_ids]))
 
         if len(ids_of_not_existing_object) > 0:
             self.increment_requests_count()


### PR DESCRIPTION
Given the following list to multiload...
`['stores-28050', 'stores-28050', 'stores-28050asdasd']`

RavenDB would return because it is smart enough not to duplicate results...
`[stores-28050-contents, None]`

This library was using a simple index trick that caused it to...
1. Correctly set stores-28050 = stores-28050-contents
2. Incorrectly set stores-28050 = None
3. Then not doing anything with stores-28050asdasd

The fix is to remove duplicates *while maintaining order* before querying RavenDB