### PR TITLE
RDBC-30 change adminOperations to MaintenanceOperation, DropSubscriptionCommand to DropSubscriptionConnectionCommand in subscription, fix store generate id to non id object

### DIFF
--- a/pyravendb/commands/raven_commands.py
+++ b/pyravendb/commands/raven_commands.py
@@ -356,7 +356,7 @@ class GetOperationStateCommand(RavenCommand):
 
     def create_request(self, server_node):
         self.url = "{0}/databases/{1}/operations/state?id={2}".format(server_node.url, server_node.database,
-                                                                      self.operation_id) if self.is_server_store_operation == False \
+                                                                      self.operation_id) if not self.is_server_store_operation \
             else "{0}/operations/state?id={2}".format(server_node.url, self.operation_id)
 
     def set_response(self, response):
@@ -561,9 +561,9 @@ class DeleteSubscriptionCommand(RavenCommand):
         pass
 
 
-class DropSubscriptionCommand(RavenCommand):
+class DropSubscriptionConnectionCommand(RavenCommand):
     def __init__(self, name):
-        super(DropSubscriptionCommand, self).__init__(method="POST")
+        super(DropSubscriptionConnectionCommand, self).__init__(method="POST")
         self._name = name
 
     def create_request(self, server_node):

--- a/pyravendb/data/document_convention.py
+++ b/pyravendb/data/document_convention.py
@@ -12,7 +12,7 @@ class DocumentConvention(object):
         self.max_ids_to_catch = kwargs.get("max_ids_to_catch", 32)
         # timeout for wait to server in seconds
         self.timeout = kwargs.get("timeout", timedelta(seconds=30))
-        self.default_use_optimistic_concurrency = kwargs.get("default_use_optimistic_concurrency", True)
+        self.default_use_optimistic_concurrency = kwargs.get("use_optimistic_concurrency", False)
         self.json_default_method = DocumentConvention.json_default
         self.max_length_of_query_using_get_url = kwargs.get("max_length_of_query_using_get_url", 1024 + 512)
         self.identity_parts_separator = "/";

--- a/pyravendb/raven_operations/maintenance_operations.py
+++ b/pyravendb/raven_operations/maintenance_operations.py
@@ -5,11 +5,11 @@ from pyravendb.data.indexes import IndexDefinition
 from abc import abstractmethod
 
 
-class AdminOperation(object):
+class MaintenanceOperation(object):
     __slots__ = ['__operation']
 
     def __init__(self):
-        self.__operation = "AdminOperation"
+        self.__operation = "MaintenanceOperation"
 
     @property
     def operation(self):
@@ -20,7 +20,7 @@ class AdminOperation(object):
         raise NotImplementedError
 
 
-class DeleteIndexOperation(AdminOperation):
+class DeleteIndexOperation(MaintenanceOperation):
     def __init__(self, index_name):
         super(DeleteIndexOperation, self).__init__()
         self._index_name = index_name
@@ -43,7 +43,7 @@ class DeleteIndexOperation(AdminOperation):
             pass
 
 
-class GetIndexOperation(AdminOperation):
+class GetIndexOperation(MaintenanceOperation):
     def __init__(self, index_name):
         """
         @param str index_name: The name of the index
@@ -87,7 +87,7 @@ class GetIndexOperation(AdminOperation):
                 raise response.raise_for_status()
 
 
-class GetIndexNamesOperation(AdminOperation):
+class GetIndexNamesOperation(MaintenanceOperation):
     def __init__(self, start, page_size):
         super(GetIndexNamesOperation, self).__init__()
         self._start = start
@@ -121,7 +121,7 @@ class GetIndexNamesOperation(AdminOperation):
             return response["Results"]
 
 
-class PutIndexesOperation(AdminOperation):
+class PutIndexesOperation(MaintenanceOperation):
     def __init__(self, *indexes_to_add):
         if len(indexes_to_add) == 0:
             raise ValueError("Invalid indexes_to_add")
@@ -165,6 +165,6 @@ class PutIndexesOperation(AdminOperation):
                 response.raise_for_status()
 
 
-class GetStatisticsOperation(AdminOperation):
+class GetStatisticsOperation(MaintenanceOperation):
     def get_command(self, conventions):
         return GetStatisticsCommand()

--- a/pyravendb/raven_operations/server_operations.py
+++ b/pyravendb/raven_operations/server_operations.py
@@ -204,7 +204,7 @@ class CreateClientCertificateOperation(ServerOperation):
         @param str password: The password of the certificate
         """
         if name is None:
-            raise ValueError("name cannot by None")
+            raise ValueError("name cannot be None")
         if permissions is None:
             raise ValueError("permissions cannot be None")
 
@@ -220,7 +220,7 @@ class CreateClientCertificateOperation(ServerOperation):
     class _CreateClientCertificateCommand(RavenCommand):
         def __init__(self, name, permissions, clearance, password):
             if name is None:
-                raise ValueError("name cannot by None")
+                raise ValueError("name cannot be None")
             if permissions is None:
                 raise ValueError("permissions cannot be None")
 

--- a/pyravendb/store/session_query.py
+++ b/pyravendb/store/session_query.py
@@ -160,7 +160,7 @@ class Query(object):
             for token in self._group_by_tokens:
                 if index > 0:
                     query_builder.append(",")
-                    query_builder.append(token.write)
+                query_builder.append(token.write)
                 index += 1
 
     def build_where(self, query_builder):

--- a/pyravendb/subscriptions/document_subscriptions.py
+++ b/pyravendb/subscriptions/document_subscriptions.py
@@ -1,6 +1,6 @@
 from pyravendb.custom_exceptions.exceptions import InvalidOperationException
 from pyravendb.commands.raven_commands import CreateSubscriptionCommand, DeleteSubscriptionCommand, \
-    GetSubscriptionsCommand, GetSubscriptionStateCommand, DropSubscriptionCommand
+    GetSubscriptionsCommand, GetSubscriptionStateCommand, DropSubscriptionConnectionCommand
 from threading import Lock
 from pyravendb.subscriptions.subscription import SubscriptionWorker
 from pyravendb.subscriptions.data import *
@@ -68,7 +68,7 @@ class DocumentSubscriptions:
         @param str database: The name of the database
         """
         request_executor = self._store.get_request_executor(database)
-        command = DropSubscriptionCommand(name)
+        command = DropSubscriptionConnectionCommand(name)
         request_executor.execute(command)
 
     def get_subscriptions(self, start, take, database=None):

--- a/pyravendb/subscriptions/subscription.py
+++ b/pyravendb/subscriptions/subscription.py
@@ -8,9 +8,6 @@ from pyravendb.subscriptions.data import IncrementalJsonParser
 from pyravendb.custom_exceptions.exceptions import *
 from pyravendb.connection.requests_executor import RequestsExecutor
 
-logging.basicConfig(filename='responses.log', level=logging.DEBUG)
-log = logging.getLogger()
-
 
 class SubscriptionWorker:
     def __init__(self, options, store, database_name, confirm_callback=None, object_type=None,
@@ -28,6 +25,12 @@ class SubscriptionWorker:
         self._store = store
         self._database_name = database_name if database_name is not None else store.database
         self._logger = logging.getLogger("subscription_" + self._database_name)
+        handler = logging.FileHandler('subscriptions.log')
+        formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+        handler.setFormatter(formatter)
+        self._logger.addHandler(handler)
+        self._logger.setLevel(logging.DEBUG)
+
         if options.subscription_name is None:
             raise AttributeError("SubscriptionWorkerOptions must specify the subscription_name", "options")
 
@@ -206,7 +209,7 @@ class SubscriptionWorker:
                 self._my_socket.close()
             self._subscription_thread.join()
         except Exception as ex:
-            self._logger.info("Error during closing the subscription", ex)
+            self._logger.debug("Error during closing the subscription: " + str(ex))
 
     def __enter__(self):
         return self

--- a/pyravendb/tests/operations_tests/test_maintenance_operations.py
+++ b/pyravendb/tests/operations_tests/test_maintenance_operations.py
@@ -1,26 +1,26 @@
 from pyravendb.tests.test_base import *
-from pyravendb.raven_operations.admin_operations import *
+from pyravendb.raven_operations.maintenance_operations import *
 from pyravendb.commands.raven_commands import DeleteIndexCommand
 import unittest
 
 
-class TestAdminOperations(TestBase):
+class TestMaintenanceOperations(TestBase):
     def tearDown(self):
-        super(TestAdminOperations, self).tearDown()
+        super(TestMaintenanceOperations, self).tearDown()
         TestBase.delete_all_topology_files()
 
     def test_put_index_operation(self):
         index_definition_users = IndexDefinition("Users", "from doc in docs.Users select new {doc.Name}")
         index_definition_dogs = IndexDefinition("Dogs", "from doc in docs.Dogs select new {doc.brand}")
 
-        self.store.admin.send(PutIndexesOperation(index_definition_dogs, index_definition_users))
-        index_names = self.store.admin.send(GetIndexNamesOperation(0, 25))
+        self.store.maintenance.send(PutIndexesOperation(index_definition_dogs, index_definition_users))
+        index_names = self.store.maintenance.send(GetIndexNamesOperation(0, 25))
         self.assertTrue("Users" in index_names and "Dogs" in index_names)
 
     def test_get_index_operation(self):
         index_definition_users = IndexDefinition("Users", "from doc in docs.Users select new {doc.Name}")
-        self.store.admin.send(PutIndexesOperation(index_definition_users))
-        users_index_definition = self.store.admin.send(GetIndexOperation("Users"))
+        self.store.maintenance.send(PutIndexesOperation(index_definition_users))
+        users_index_definition = self.store.maintenance.send(GetIndexOperation("Users"))
         self.assertEqual(users_index_definition.name, "Users")
 
 

--- a/pyravendb/tests/operations_tests/test_operations.py
+++ b/pyravendb/tests/operations_tests/test_operations.py
@@ -34,7 +34,7 @@ class TestOperations(TestBase):
         self.assertIsNone(attachment)
 
     def test_patch_by_index(self):
-        self.store.admin.send(PutIndexesOperation(
+        self.store.maintenance.send(PutIndexesOperation(
             IndexDefinition("Patches", maps="from doc in docs.Patches select new {patched = doc.patched}")))
 
         with self.store.open_session() as session:
@@ -64,7 +64,7 @@ class TestOperations(TestBase):
             self.store.operations.send(operation)
 
     def test_delete_by_index(self):
-        self.store.admin.send(PutIndexesOperation(
+        self.store.maintenance.send(PutIndexesOperation(
             IndexDefinition("Users", maps="from doc in docs.Users select new {name=doc.name}")))
 
         with self.store.open_session() as session:

--- a/pyravendb/tests/operations_tests/test_server_operations.py
+++ b/pyravendb/tests/operations_tests/test_server_operations.py
@@ -11,17 +11,17 @@ class TestServerOperations(TestBase):
 
     def test_create_database_name_longer_than_260_chars(self):
         name = "long_database_name_" + ''.join(['z' for _ in range(100)])
-        self.store.admin.server.send(CreateDatabaseOperation(database_name=name))
+        self.store.maintenance.server.send(CreateDatabaseOperation(database_name=name))
         TestBase.wait_for_database_topology(self.store, name)
-        database_names = self.store.admin.server.send(GetDatabaseNamesOperation(0, 3))
+        database_names = self.store.maintenance.server.send(GetDatabaseNamesOperation(0, 3))
         self.assertTrue(name in database_names)
 
     def test_cannot_create_database_with_the_same_name(self):
         name = "Duplicate"
-        self.store.admin.server.send(CreateDatabaseOperation(database_name=name))
+        self.store.maintenance.server.send(CreateDatabaseOperation(database_name=name))
         TestBase.wait_for_database_topology(self.store, name)
         with self.assertRaises(Exception):
-            self.store.admin.server.send(CreateDatabaseOperation(database_name=name))
+            self.store.maintenance.server.send(CreateDatabaseOperation(database_name=name))
 
 
 if __name__ == "__main__":

--- a/pyravendb/tests/raven_commands_tests/test_by_index_actions.py
+++ b/pyravendb/tests/raven_commands_tests/test_by_index_actions.py
@@ -5,7 +5,7 @@ from pyravendb.custom_exceptions import exceptions
 from pyravendb.data.indexes import IndexFieldOptions, SortOptions, IndexDefinition
 from pyravendb.data.query import IndexQuery
 from pyravendb.tests.test_base import TestBase
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation
 from pyravendb.raven_operations.operations import QueryOperationOptions, PatchByQueryOperation, DeleteByQueryOperation
 
 
@@ -20,7 +20,7 @@ class TestByIndexActions(TestBase):
         self.index_sort = IndexDefinition(name="Testing_Sort", maps=index_map,
                                           fields={"DocNumber": IndexFieldOptions(sort_options=SortOptions.numeric)})
         self.patch = "this.Name = 'Patched';"
-        self.store.admin.send(PutIndexesOperation(self.index_sort))
+        self.store.maintenance.send(PutIndexesOperation(self.index_sort))
         self.requests_executor = self.store.get_request_executor()
         for i in range(100):
             put_command = PutDocumentCommand("testing/" + str(i),

--- a/pyravendb/tests/raven_commands_tests/test_index_actions.py
+++ b/pyravendb/tests/raven_commands_tests/test_index_actions.py
@@ -1,6 +1,6 @@
 import unittest
 from pyravendb.data.indexes import IndexDefinition
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation, GetIndexOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation, GetIndexOperation
 from pyravendb.commands.raven_commands import DeleteIndexCommand
 from pyravendb.tests.test_base import TestBase
 

--- a/pyravendb/tests/raven_commands_tests/test_query.py
+++ b/pyravendb/tests/raven_commands_tests/test_query.py
@@ -3,6 +3,7 @@ from pyravendb.tests.test_base import TestBase
 from pyravendb.commands.raven_commands import *
 from pyravendb.custom_exceptions.exceptions import ErrorResponseException
 from pyravendb.data.document_convention import DocumentConvention
+import time
 
 
 class TestQuery(TestBase):
@@ -38,7 +39,12 @@ class TestQuery(TestBase):
                                                             wait_for_non_stale_results=True),
                                      conventions=DocumentConvention(),
                                      index_entries_only=True)
-        response = self.requests_executor.execute(query_command)
+
+        start = time.time()
+        while True and time.time() - start < 30:
+            response = self.requests_executor.execute(query_command)
+            if not response["IsStale"]:
+                break
         self.assertFalse("@metadata" in response["Results"][0])
 
     def test_fail_with_no_index(self):

--- a/pyravendb/tests/session_tests/test_facets.py
+++ b/pyravendb/tests/session_tests/test_facets.py
@@ -1,6 +1,6 @@
 from pyravendb.tests.test_base import TestBase
 from pyravendb.data.query import Facet, FacetMode
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation
 from pyravendb.data.indexes import IndexDefinition
 import unittest
 
@@ -19,7 +19,7 @@ class ProductsAndPricePerUnit:
         self.index_definition = IndexDefinition(name=ProductsAndPricePerUnit.__name__, maps=self.maps)
 
     def execute(self, store):
-        store.admin.send(PutIndexesOperation(self.index_definition))
+        store.maintenance.send(PutIndexesOperation(self.index_definition))
 
 
 class TestFacets(TestBase):

--- a/pyravendb/tests/session_tests/test_full_text_search.py
+++ b/pyravendb/tests/session_tests/test_full_text_search.py
@@ -1,7 +1,7 @@
 from pyravendb.tests.test_base import TestBase
 from pyravendb.data.indexes import IndexDefinition, FieldIndexing, IndexFieldOptions
 from pyravendb.data.query import QueryOperator
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation
 from datetime import datetime
 
 
@@ -33,7 +33,7 @@ class LastFmAnalyzed(object):
                                                 fields={"query": IndexFieldOptions(indexing=FieldIndexing.search)})
 
     def execute(self, store):
-        store.admin.send(PutIndexesOperation(self.index_definition))
+        store.maintenance.send(PutIndexesOperation(self.index_definition))
 
 
 class FullTextSearchTest(TestBase):

--- a/pyravendb/tests/session_tests/test_query.py
+++ b/pyravendb/tests/session_tests/test_query.py
@@ -1,5 +1,5 @@
 from pyravendb.tests.test_base import TestBase
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation
 from pyravendb.custom_exceptions import exceptions
 from pyravendb.data.indexes import IndexDefinition, SortOptions, IndexFieldOptions
 import unittest
@@ -44,7 +44,7 @@ class TestQuery(TestBase):
         second_index_definition = IndexDefinition(name="SelectTestingIndex", maps=maps,
                                                   fields={"order_and_id": IndexFieldOptions(storage=True)})
 
-        self.store.admin.send(PutIndexesOperation(index_definition, second_index_definition))
+        self.store.maintenance.send(PutIndexesOperation(index_definition, second_index_definition))
 
         with self.store.open_session() as session:
             session.store(Product("test101", 2, "a"), "products/101")

--- a/pyravendb/tests/session_tests/test_store_entities.py
+++ b/pyravendb/tests/session_tests/test_store_entities.py
@@ -25,16 +25,16 @@ class TestSessionStore(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            self.assertIsNotNone(session.load(foo.Id))
+            self.assertIsNotNone(session.load("foos/1-A"))
 
     def test_store_with_key(self):
         foo = Foo("test", 20)
         with self.store.open_session() as session:
-            session.store(foo, "testingStore/1")
+            session.store(foo, "testingStore/1-A")
             session.save_changes()
 
         with self.store.open_session() as session:
-            self.assertEqual(session.load("testingStore/1").key, 20)
+            self.assertEqual(session.load("testingStore/1-A").key, 20)
 
     def test_store_after_delete_fail(self):
         foo = Foo("test", 20)
@@ -45,7 +45,27 @@ class TestSessionStore(TestBase):
         with self.store.open_session() as session:
             session.delete("testingStore")
             with self.assertRaises(exceptions.InvalidOperationException):
-                session.store(foo)
+                session.store(foo, "testingStore")
+
+    def _save_documents(self, documents):
+        with self.store.open_session() as session:
+            for document in documents:
+                session.store(document)
+            session.save_changes()
+
+    def test_store_the_same_documents_should_work(self):
+        documents = []
+        for i in range(0, 40):
+            documents.append(Foo("IdanHaim", i))
+
+        self._save_documents(documents)
+        self._save_documents(documents)
+        self._save_documents(documents)
+        self._save_documents(documents)
+
+        with self.store.open_session() as session:
+            results = list(session.query().raw_query("From Foos"))
+            self.assertEqual(len(results), 40 * 4)
 
 
 if __name__ == "__main__":

--- a/pyravendb/tools/generate_id.py
+++ b/pyravendb/tools/generate_id.py
@@ -1,7 +1,8 @@
 class GenerateEntityIdOnTheClient(object):
     @staticmethod
     def try_set_id_on_entity(entity, key):
-        entity.Id = key
+        if hasattr(entity, "Id"):
+            entity.Id = key
 
     @staticmethod
     def try_get_id_from_instance(entity):

--- a/pyravendb/tryouts/program.py
+++ b/pyravendb/tryouts/program.py
@@ -2,7 +2,7 @@ from pyravendb.store.document_store import DocumentStore
 from pyravendb.store import document_store
 from pyravendb.commands.raven_commands import GetTcpInfoCommand
 from pyravendb.raven_operations.server_operations import CreateDatabaseOperation, DeleteDatabaseOperation
-from pyravendb.raven_operations.admin_operations import PutIndexesOperation, GetStatisticsOperation
+from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation, GetStatisticsOperation
 from pyravendb.subscriptions.data import SubscriptionCreationOptions
 from pyravendb.data.indexes import IndexDefinition, IndexFieldOptions, FieldIndexing
 from requests.exceptions import RequestException
@@ -56,7 +56,7 @@ class UsersByName:
                                                 fields={"name": IndexFieldOptions(indexing=FieldIndexing.search)})
 
     def execute(self, document_store):
-        document_store.admin.send(PutIndexesOperation(self.index_definition))
+        document_store.maintenance.send(PutIndexesOperation(self.index_definition))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix tests, typos
- All Operation Executors are now act as lazy in DocumentStore
- default_use_optimistic_concurrency is False by default 