### PR TITLE
RDBC-92 Add Mappers

### DIFF
--- a/pyravendb/store/session_query.py
+++ b/pyravendb/store/session_query.py
@@ -41,7 +41,6 @@ class Query(object):
         self._current_clause_depth = None
         self.is_intersect = None
         self.the_wait_for_non_stale_results = False
-        self.fetch = None
         self._query = None
         self.start = None
         self.page_size = None
@@ -92,7 +91,6 @@ class Query(object):
         self.cutoff_etag = None
         self.wait_for_non_stale_results = wait_for_non_stale_results
         self.timeout = timeout if timeout is not None else self.session.conventions.timeout
-        self.fetch = None
         self._query = None
         self.last_equality = None
         self.is_distinct = False
@@ -799,13 +797,13 @@ class Query(object):
         response_includes = response.pop("Includes", None)
         self.session.save_includes(response_includes)
         for result in response_results:
-            entity, metadata, original_metadata = Utils.convert_to_entity(result, self.object_type, conventions,
-                                                                          self.nested_object_types,
-                                                                          fetch=False if not self.fetch else True)
+            entity, metadata, original_metadata, original_document = Utils.convert_to_entity(result, self.object_type,
+                                                                                             conventions,
+                                                                                             self.nested_object_types)
             if self.object_type != dict and not self.fields_to_fetch:
                 self.session.save_entity(key=original_metadata.get("@id", None), entity=entity,
                                          original_metadata=original_metadata,
-                                         metadata=metadata, document=result)
+                                         metadata=metadata, original_document=original_document)
             results.append(entity)
 
         if self._with_statistics:

--- a/pyravendb/subscriptions/subscription.py
+++ b/pyravendb/subscriptions/subscription.py
@@ -342,9 +342,9 @@ class SubscriptionBatch:
         last_change_vector = None
         for item in self.raw_items:
 
-            entity, metadata, _ = Utils.convert_to_entity(item['Data'], self._object_type,
-                                                          self._store.conventions,
-                                                          nested_object_types=self._nested_object_type)
+            entity, metadata, _, _ = Utils.convert_to_entity(item['Data'], self._object_type,
+                                                             self._store.conventions,
+                                                             nested_object_types=self._nested_object_type)
             if not metadata:
                 raise InvalidOperationException("Document must have a @metadata field")
             document_id = metadata.get('@id', None)

--- a/pyravendb/tests/session_tests/test_load.py
+++ b/pyravendb/tests/session_tests/test_load.py
@@ -1,5 +1,4 @@
 from pyravendb.tests.test_base import TestBase
-from pyravendb.store.document_store import DocumentStore
 from pyravendb.custom_exceptions import exceptions
 import unittest
 

--- a/pyravendb/tests/session_tests/test_mappers.py
+++ b/pyravendb/tests/session_tests/test_mappers.py
@@ -1,0 +1,78 @@
+from pyravendb.tests.test_base import TestBase
+from pyravendb.data.document_conventions import DocumentConventions
+import unittest
+
+
+class Address:
+    def __init__(self, street, city, state):
+        self.street = street
+        self.city = city
+        self.state = state
+
+
+class Owner:
+    def __init__(self, name, address):
+        self.name = name
+        self.address = address
+
+
+class Dog:
+    def __init__(self, name, owner):
+        self.name = name
+        self.owner = owner
+
+
+def get_dog(key, value):
+    if key is None or value is None:
+        return None
+
+    if key == "address":
+        return Address(**value)
+    elif key == "owner":
+        return Owner(**value)
+
+
+class TestMappers(TestBase):
+    def setUp(self):
+        self.setConvention(DocumentConventions(mappers={Dog: get_dog}))
+        super(TestMappers, self).setUp()
+        with self.store.open_session() as session:
+            session.store(Dog(name="Donald", owner=Owner(name="Idan", address=Address("Ru", "Harish", "Israel"))),
+                          key="Dogs/1-A")
+            session.store(Dog("Scooby Doo", Owner("Shaggy ", Address("UnKnown", "UnKnown", "America"))), key="Dogs/2-A")
+            session.store(Dog("Courage", Owner("John R. Dilworth", Address("Middle of Nowhere", "UnKnown", "America"))),
+                          key="Dogs/3-A")
+            session.save_changes()
+
+    def tearDown(self):
+        super(TestMappers, self).tearDown()
+        self.delete_all_topology_files()
+
+    def test_load_with_mappers(self):
+        with self.store.open_session() as session:
+            dog = session.load("Dogs/3-A", object_type=Dog)
+            self.assertIsNotNone(dog)
+            self._check_dog_type(dog)
+
+    def test_query_with_mappers(self):
+        with self.store.open_session() as session:
+            results = list(session.query(object_type=Dog))
+            self.assertIsNotNone(results)
+            for result in results:
+                self._check_dog_type(result)
+
+    def test_multi_load_with_mappers(self):
+        with self.store.open_session() as session:
+            dogs = session.load(["Dogs/1-A", "Dogs/2-A", "Dogs/3-A"], object_type=Dog)
+            self.assertIsNotNone(dogs)
+            for dog in dogs:
+                self._check_dog_type(dog)
+
+    def _check_dog_type(self, obj):
+        self.assertTrue(isinstance(obj, Dog))
+        self.assertTrue(isinstance(obj.owner, Owner))
+        self.assertTrue(isinstance(obj.owner.address, Address))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyravendb/tests/test_base.py
+++ b/pyravendb/tests/test_base.py
@@ -41,10 +41,16 @@ class TestBase(unittest.TestCase):
             topology = store.maintenance.server.send(GetDatabaseRecordOperation(database_name))
         return topology
 
+    def setConvention(self, conventions):
+        self.conventions = conventions
+
     def setUp(self):
-        self.default_urls = ["http://localhost.fiddler:8084"]
+        conventions = getattr(self, "conventions", None)
+        self.default_urls = ["http://localhost.fiddler:8080"]
         self.default_database = "NorthWindTest"
         self.store = DocumentStore(urls=self.default_urls, database=self.default_database)
+        if conventions:
+            self.store.conventions = conventions
         self.store.initialize()
         created = False
         while not created:

--- a/pyravendb/tools/custom_decoder.py
+++ b/pyravendb/tools/custom_decoder.py
@@ -1,0 +1,49 @@
+from pyravendb.tools.utils import Utils
+import json
+
+
+class JsonDecoder(json.JSONDecoder):
+    """
+    This custom JsonDecoder can add to json.loads function to work with pyravendb mappers solution.
+    just use it like this json.loads(YOUR_OBJECT, cls=JsonDecoder, object_mapper=YOUR_MAPPER)
+    Note that that last object that returns from the loads function will be a dict.
+    To get the dict as you custom object you can create it with the return dict or use the parse_json method
+    """
+
+    def __init__(self, **kwargs):
+        self.object_mapper = kwargs.pop("object_mapper", lambda key, value: None)
+        super(JsonDecoder, self).__init__(object_hook=self.object_hook)
+        self.step_down = None
+
+    def object_hook(self, dict_object):
+        if self.step_down is not None:
+            for key in dict_object:
+                result = self.object_mapper(key, dict_object[key])
+                if result is not None:
+                    dict_object[key] = result
+        self.step_down = dict_object
+        return self.step_down
+
+
+def parse_json(json_string, object_type, mappers):
+    """
+    This function will use the custom JsonDecoder and the conventions.mappers to recreate your custom object
+    in the parse json string state just call this method with the json_string your complete object_type and with your
+    mappers dict.
+    the mappers dict must contain in the key the object_type (ex. User) and the value will contain a method that get
+    key, value (the key will be the name of the object property we like to parse and the value
+    will be the properties of the object)
+    """
+    obj = json.loads(json_string, cls=JsonDecoder, object_mapper=mappers.get(object_type, None))
+
+    if obj is not None:
+        try:
+            obj = object_type(**obj)
+        except TypeError:
+            initialize_dict, set_needed = Utils.make_initialize_dict(obj, object_type.__init__)
+            o = object_type(**initialize_dict)
+            if set_needed:
+                for key, value in obj.items():
+                    setattr(o, key, value)
+            obj = o
+    return obj

--- a/pyravendb/tools/projection.py
+++ b/pyravendb/tools/projection.py
@@ -1,0 +1,29 @@
+def create_entity_with_mapper(dict_obj, mapper, object_type):
+    from pyravendb.tools.utils import Utils
+
+    def parse_dict_rec(data):
+        try:
+            if not isinstance(data, dict):
+                for i in range(len(data)):
+                    data[i] = Utils.initialize_object(parse_dict_rec(data[i])[0], object_type)
+                return data, False
+
+            for key in data:
+                if isinstance(data[key], dict):
+                    parse_dict_rec(data[key])
+                    data[key] = mapper(key, data[key])
+                    if key is None:
+                        pass
+                if isinstance(data[key], (tuple, list)):
+                    for item in data[key]:
+                        parse_dict_rec(item)
+                    data[key] = mapper(key, data[key])
+            return data, True
+        except TypeError as e:
+            raise TypeError("Can't parse to custom object", e)
+
+    first_parsed, need_to_parse = parse_dict_rec(dict_obj)
+    # After create a complete dict for our object we need to create the object with the object_type
+    if first_parsed is not None and need_to_parse:
+        return Utils.initialize_object(first_parsed, object_type)
+    return first_parsed

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='pyravendb',
     packages=find_packages(),
-    version='4.0.5.0',
+    version='4.0.6.0',
     long_description=open("README.rst").read(),
     description='This is the official python client for RavenDB v4.0 document database',
     author='RavenDB',


### PR DESCRIPTION
- DocumentConventions.mappers have been added to be able to parse custom objects via user methods
- Database can be None when initialize the store
- Add Custom decoder for parsing custom objects
- Fix convert_to_entity
- Fix make_initialize_dict to be able to work with object with different properties