### PR TITLE
Add paging to GetDocumentCommand and create GetDocumentByPrefixCommand

### DIFF
--- a/pyravendb/tests/raven_commands_tests/test_get.py
+++ b/pyravendb/tests/raven_commands_tests/test_get.py
@@ -8,11 +8,14 @@ class TestGet(TestBase):
         super(TestGet, self).setUp()
         put_command = PutDocumentCommand("products/101", {"Name": "test", "@metadata": {}})
         put_command2 = PutDocumentCommand("products/10", {"Name": "test", "@metadata": {}})
+        put_command3 = PutDocumentCommand("products/102", {"Name": "test", "@metadata": {}})
         self.requests_executor = self.store.get_request_executor()
         self.requests_executor.execute(put_command)
         self.requests_executor.execute(put_command2)
+        self.requests_executor.execute(put_command3)
         self.response = self.requests_executor.execute(GetDocumentCommand("products/101"))
         self.other_response = self.requests_executor.execute(GetDocumentCommand("products/10"))
+        self.paged_response = self.requests_executor.execute(GetDocumentCommand("products/102", start=2, page_size=1))
 
     def tearDown(self):
         super(TestGet, self).tearDown()
@@ -24,6 +27,10 @@ class TestGet(TestBase):
     def test_not_equal(self):
         self.assertNotEqual(self.response["Results"][0]["@metadata"]["@id"],
                             self.other_response["Results"][0]["@metadata"]["@id"])
+
+    def test_paging(self):
+        self.assertEqual(len(self.paged_response["Results"]), 1)
+        self.assertEqual(self.paged_response["Results"][0]["@metadata"]["@id"], "products/102")
 
     def test_null(self):
         self.assertIsNone(self.requests_executor.execute(GetDocumentCommand("product")))

--- a/pyravendb/tests/raven_commands_tests/test_get_by_prefix.py
+++ b/pyravendb/tests/raven_commands_tests/test_get_by_prefix.py
@@ -1,0 +1,74 @@
+import unittest
+
+from pyravendb.commands.raven_commands import (
+    PutDocumentCommand,
+    GetDocumentsByPrefixCommand,
+)
+from pyravendb.tests.test_base import TestBase
+
+
+class TestGetDocumentsByPrefixCommand(TestBase):
+    def setUp(self):
+        super(TestGetDocumentsByPrefixCommand, self).setUp()
+        self.requests_executor = self.store.get_request_executor()
+        self.requests_executor.execute(
+            PutDocumentCommand("products/MB-200", {"Name": "test", "@metadata": {}})
+        )
+        self.requests_executor.execute(
+            PutDocumentCommand("products/MB-201", {"Name": "test", "@metadata": {}})
+        )
+        self.requests_executor.execute(
+            PutDocumentCommand("products/MB-100", {"Name": "test", "@metadata": {}})
+        )
+        self.requests_executor.execute(
+            PutDocumentCommand("products/MB-101", {"Name": "test", "@metadata": {}})
+        )
+        self.requests_executor.execute(
+            PutDocumentCommand("products/BM-100", {"Name": "test", "@metadata": {}})
+        )
+        self.requests_executor.execute(
+            PutDocumentCommand("products/BM-200", {"Name": "test", "@metadata": {}})
+        )
+
+    def tearDown(self):
+        super(TestGetDocumentsByPrefixCommand, self).tearDown()
+        self.delete_all_topology_files()
+
+    def test_init_WHEN_start_with_is_empty_THEN_raise(self):
+        self.assertRaises(ValueError, GetDocumentsByPrefixCommand, None)
+
+    def test_start_with(self):
+        response = self.requests_executor.execute(
+            GetDocumentsByPrefixCommand("products/MB")
+        )
+        self.assertEqual(len(response["Results"]), 4)
+
+    def test_matches(self):
+        response = self.requests_executor.execute(
+            GetDocumentsByPrefixCommand("products/MB-", matches="2*")
+        )
+        self.assertEqual(len(response["Results"]), 2)
+
+    def test_excludes(self):
+        response = self.requests_executor.execute(
+            GetDocumentsByPrefixCommand("products/BM-", exclude="2*")
+        )
+        self.assertEqual(len(response["Results"]), 1)
+
+    def test_start_after(self):
+        response = self.requests_executor.execute(
+            GetDocumentsByPrefixCommand(
+                "products/MB-", matches="2*", start_after="products/MB-200"
+            )
+        )
+        self.assertEqual(len(response["Results"]), 1)
+
+    def test_page(self):
+        response = self.requests_executor.execute(
+            GetDocumentsByPrefixCommand("products/MB", start=1, page_size=2)
+        )
+        self.assertEqual(len(response["Results"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New features:

- Add `start`, `page_size` and `counter_includes` parameters to `GetDocumentCommand`
- Create `GetDocumentsByPrefixCommand` matching the [documentation](https://ravendb.net/docs/article-page/5.1/csharp/client-api/rest-api/document-commands/get-documents-by-prefix) specs.

**Obs**: I couldn't find a documentation describing how to contribute to this repo, please let me know anything I'm missing.