### PR TITLE
Customize Collection Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,5 +286,41 @@ with DocumentStore(urls=["http://localhost:8080"], database="PyRavenDB") as stor
         result = session.load("dogs/1-A", object_type=Dog)
 ```
 
+### Custom Class Name
+
+Now you can customize the collection name. This is necessary when the language is not English and the plural generated is not correct. It is also important for environments where a Python program will access a RavenDB database that is also powered by a C# program where it is already possible to customize the name.
+
+As with mappers, you can change the name of collections via `DocumentConvention`, as shown below.
+
+If a custom name is not specified, RavenDB will automatically generate the collection name as it did until now.
+
+##### Example:
+
+```python
+class Address:
+    def __init__(self, street, city, state):
+        self.street = street
+        self.city = city
+        self.state = state
+        self.Id: str = None
+
+
+class Customer:
+    def __init__(self, name):
+        self.name = name
+        self.Id: str = None
+
+class SomeClass:
+    def __init__(self, name):
+        self.name = name
+        self.Id: str = None
+
+with DocumentStore(urls=["http://localhost:8080"], database="PyRavenDB") as store:
+    store.conventions.default_collection_names = {Address: 'Address',SomeClass:'SomeNewCoolName'}
+    store.initialize()
+    
+
+```
+
 ##### Bug Tracker
 http://issues.hibernatingrhinos.com/issues/RDBC

--- a/pyravendb/hilo/hilo_generator.py
+++ b/pyravendb/hilo/hilo_generator.py
@@ -90,7 +90,7 @@ class MultiTypeHiLoKeyGenerator(object):
         self.key_generators_by_tag = {}
 
     def generate_document_key(self, entity):
-        tag = self._conventions.default_transform_type_tag_name(entity.__class__.__name__)
+        tag = self._conventions.default_transform_type_tag_name(entity)
         if tag is None:
             return None
         else:

--- a/pyravendb/tests/session_tests/test_advanced.py
+++ b/pyravendb/tests/session_tests/test_advanced.py
@@ -1,14 +1,15 @@
-from pyravendb.tests.test_base import TestBase
+import os
+import unittest
+
+from pyravendb.custom_exceptions.exceptions import InvalidOperationException
 from pyravendb.data.indexes import IndexDefinition
 from pyravendb.raven_operations.maintenance_operations import PutIndexesOperation
-from pyravendb.custom_exceptions.exceptions import InvalidOperationException
-import unittest
-import os
+from pyravendb.tests.test_base import TestBase
 
-parent_path = os.path.dirname(os.getcwd())
+parent_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if not parent_path.endswith("tests"):
-    parent_path += "\\tests"
-OUT_PUT_FILE_PATH = f"{parent_path}\\output.txt"
+    parent_path = os.path.join(parent_path, "tests")
+OUT_PUT_FILE_PATH = os.path.join(parent_path, "output.txt")
 
 
 class User:

--- a/pyravendb/tests/session_tests/test_collection_name.py
+++ b/pyravendb/tests/session_tests/test_collection_name.py
@@ -1,0 +1,89 @@
+import unittest
+
+from pyravendb.commands.raven_commands import GetDocumentCommand
+from pyravendb.custom_exceptions.exceptions import InvalidOperationException
+from pyravendb.data.document_conventions import DocumentConventions
+from pyravendb.tests.test_base import TestBase
+
+
+class Address:
+    def __init__(self, street, city, state):
+        self.street = street
+        self.city = city
+        self.state = state
+        self.Id: str = None
+
+
+class Customer:
+    def __init__(self, name):
+        self.name = name
+        self.Id: str = None
+
+class SomeClass:
+    def __init__(self, name):
+        self.name = name
+        self.Id: str = None
+
+
+class TesteCollectionName(TestBase):
+    def setUp(self):
+        self.setConvention(DocumentConventions(collection_names={Address: 'Address',SomeClass:'SomeNewCoolName'}))
+        super(TesteCollectionName, self).setUp()
+        self.requests_executor = self.store.get_request_executor()
+
+    def tearDown(self):
+        super(TesteCollectionName, self).tearDown()
+        self.delete_all_topology_files()
+
+    def test_id_prefix_default(self):
+        with self.store.open_session() as session:
+            c = Customer(name="John")
+            session.store(c)
+            session.save_changes()
+            assert c.Id.startswith('customers/')
+
+    def test_collection_name_default(self):
+        with self.store.open_session() as session:
+            c = Customer(name="John")
+            session.store(c, key="customer/123123-ABC")
+            session.save_changes()
+            response = self.requests_executor.execute(GetDocumentCommand("customer/123123-ABC"))
+            assert response["Results"][0]["@metadata"]["@collection"] == "Customers"
+
+    def test_id_prefix_custom(self):
+        with self.store.open_session() as session:
+            c = Address(street='Baker Street', city='Westminster', state='London')
+            session.store(c)
+            session.save_changes()
+            assert c.Id.startswith('address/')
+
+    def test_collection_name_custom(self):
+        with self.store.open_session() as session:
+            c = Address(street='Baker Street', city='Westminster', state='London')
+            session.store(c, key="address/123-A")
+            session.save_changes()
+            response = self.requests_executor.execute(GetDocumentCommand("address/123-A"))
+            assert response["Results"][0]["@metadata"]["@collection"] == "Address"
+
+    def test_id_prefix_custom_composite_name(self):
+        with self.store.open_session() as session:
+            c = SomeClass(name="xpto")
+            session.store(c)
+            session.save_changes()
+            assert c.Id.startswith('SomeNewCoolName/')
+
+    def test_collection_name_custom_composite_name(self):
+        with self.store.open_session() as session:
+            c = SomeClass(name="xpto")
+            session.store(c,key="SomeNewCoolName/111-A")
+            session.save_changes()
+            response = self.requests_executor.execute(GetDocumentCommand("SomeNewCoolName/111-A"))
+            assert response["Results"][0]["@metadata"]["@collection"] == "SomeNewCoolName"
+
+    def test_shouldnt_allow_change_after_initialize(self):
+        with self.assertRaises(InvalidOperationException) as context:
+            self.store.conventions.default_collection_names = {Address: 'Addresses'}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyravendb/tests/test_base.py
+++ b/pyravendb/tests/test_base.py
@@ -46,7 +46,7 @@ class TestBase(unittest.TestCase):
 
     def setUp(self):
         conventions = getattr(self, "conventions", None)
-        self.default_urls = ["http://127.0.0.1:8080"]
+        self.default_urls = [os.getenv("ravendb_urls", "http://127.0.0.1:8080")]
         self.default_database = "NorthWindTest"
         self.store = DocumentStore(urls=self.default_urls, database=self.default_database)
         if conventions:


### PR DESCRIPTION
This change allows customizing the name of collections to more appropriate names in languages other than English. It also allows Python systems to access collections created by C# programs where it is already possible to customize the name.