### PR TITLE
Fixed pyhon3.10 imports

### DIFF
--- a/pyravendb/store/document_session.py
+++ b/pyravendb/store/document_session.py
@@ -10,7 +10,10 @@ from pyravendb.data.timeseries import TimeSeriesRangeResult
 from .session_timeseries import TimeSeries
 from .session_counters import DocumentCounters
 from typing import Dict, List
-from collections import MutableSet
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 from itertools import chain
 
 

--- a/pyravendb/tools/utils.py
+++ b/pyravendb/tools/utils.py
@@ -1,6 +1,9 @@
 from pyravendb.custom_exceptions import exceptions
 import OpenSSL.crypto
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from pyravendb.tools.projection import create_entity_with_mapper
 from datetime import datetime, timedelta
 from enum import Enum


### PR DESCRIPTION
Had some trouble getting started, my system is running `Python 3.10.11`, the imports for `MutableSet` and `Iterable` are under `collections.abc` instead of `collections`.

