### PR TITLE
RDBC-606 Conditional load doesn't require object type

### DIFF
--- a/ravendb/documents/session/operations/lazy.py
+++ b/ravendb/documents/session/operations/lazy.py
@@ -224,7 +224,9 @@ class LazySessionOperations:
 
         return self._delegate.add_lazy_operation(dict, operation, None)
 
-    def conditional_load(self, object_type: Type[_T], key: str, change_vector: str):
+    def conditional_load(
+        self, key: str, change_vector: str, object_type: Type[_T] = None
+    ) -> Lazy[ConditionalLoadResult[_T]]:
         if not key.isspace():
             raise ValueError("key cannot be None or whitespace")
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-606/Conditional-load-doesnt-require-object-type