### PR TITLE
RDBC-674 Bump to 5.2.1

### DIFF
--- a/ravendb/documents/commands/batches.py
+++ b/ravendb/documents/commands/batches.py
@@ -136,7 +136,6 @@ class SingleNodeBatchCommand(RavenCommand):
         files = {"main": None}
         for command in self.__commands:
             if command.command_type == CommandType.ATTACHMENT_PUT:
-
                 command: PutAttachmentCommandData
                 files[command.name] = (
                     command.name,

--- a/ravendb/documents/operations/attachments/__init__.py
+++ b/ravendb/documents/operations/attachments/__init__.py
@@ -274,7 +274,6 @@ class DeleteAttachmentOperation(VoidOperation):
             self.__change_vector = change_vector
 
         def create_request(self, server_node):
-
             request = requests.Request(
                 "DELETE",
                 f"{server_node.url}/databases/{server_node.database}/attachments?id={Utils.quote_key(self.__document_id)}&name={Utils.quote_key(self.__name)}",

--- a/ravendb/documents/session/operations/lazy.py
+++ b/ravendb/documents/session/operations/lazy.py
@@ -682,7 +682,6 @@ class LazyGetCompareExchangeValuesOperation(LazyOperation[_T], Generic[_T]):
 
         try:
             if response.result is not None:
-
                 if self.__cluster_session.session.no_tracking:
                     result = CaseInsensitiveDict()
                     for key, value in CompareExchangeValueResultParser.get_values(

--- a/ravendb/documents/session/operations/load_operation.py
+++ b/ravendb/documents/session/operations/load_operation.py
@@ -14,7 +14,6 @@ _T = TypeVar("_T")
 
 
 class LoadOperation:
-
     logger = logging.getLogger("load_operation")
 
     def __init__(

--- a/ravendb/http/misc.py
+++ b/ravendb/http/misc.py
@@ -21,7 +21,6 @@ class ClusterTopologyResponse:
 
     @classmethod
     def from_json(cls, json_dict: dict) -> ClusterTopologyResponse:
-
         return cls(
             json_dict["Leader"],
             json_dict["NodeTag"],

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 class RequestExecutor:
     __INITIAL_TOPOLOGY_ETAG = -2
     __GLOBAL_APPLICATION_IDENTIFIER = uuid.uuid4()
-    CLIENT_VERSION = "5.2.0"
+    CLIENT_VERSION = "5.2.1"
     logger = logging.getLogger("request_executor")
 
     # todo: initializer should take also cryptography certificates

--- a/ravendb/tests/driver/raven_test_driver.py
+++ b/ravendb/tests/driver/raven_test_driver.py
@@ -10,7 +10,6 @@ from ravendb.tests.driver.raven_server_runner import RavenServerRunner
 
 
 class RavenTestDriver:
-
     debug = False
 
     def __init__(self):

--- a/ravendb/tests/jvm_migrated_tests/suggestions_tests/test_suggestions.py
+++ b/ravendb/tests/jvm_migrated_tests/suggestions_tests/test_suggestions.py
@@ -87,7 +87,6 @@ class TestSuggestions(TestBase):
         self.set_up(self.store)
 
         with self.store.open_session() as s:
-
             options = SuggestionOptions(accuracy=0.4, distance=StringDistanceTypes.LEVENSHTEIN)
 
             suggestion_query_result = (

--- a/ravendb/tests/operations_tests/test_operations.py
+++ b/ravendb/tests/operations_tests/test_operations.py
@@ -113,7 +113,6 @@ class TestOperations(TestBase):
                 raise ErrorResponseException("Got empty or None response from the server")
 
     def test_delete_by_index(self):
-
         ind = IndexDefinition(name="Users")
         ind.maps = ["from doc in docs.Users select new {name=doc.name}"]
         self.store.maintenance.send(PutIndexesOperation(ind))

--- a/ravendb/tests/test_base.py
+++ b/ravendb/tests/test_base.py
@@ -139,7 +139,6 @@ class Patch(object):
 
 
 class TestBase(unittest.TestCase, RavenTestDriver):
-
     __global_server: Union[None, DocumentStore] = None
     __global_server_process: Union[None, Popen] = None
 

--- a/ravendb/tools/parsers.py
+++ b/ravendb/tools/parsers.py
@@ -76,7 +76,7 @@ class IncrementalJsonParser:
     def create_array(self, gen):
         arr = []
 
-        for (token, val) in gen:
+        for token, val in gen:
             if token == "end_array":
                 return arr
             arr.append(self.get_value_from_token(gen, token, val))
@@ -100,7 +100,7 @@ class IncrementalJsonParser:
     def create_object(self, gen):
         obj = {}
 
-        for (token, val) in gen:
+        for token, val in gen:
             if token == "end_map":
                 return obj
             if token == "map_key":
@@ -109,7 +109,6 @@ class IncrementalJsonParser:
         raise ParseError("End object expected, but the generator ended before we got it")
 
     def next_object(self):
-
         try:
             (_, text) = next(self.lexer)
             if IS_WEBSOCKET and text == ",":

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="5.2.0",
+    version="5.2.1",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
Needs to be done before publishing the patch - https://github.com/ravendb/ravendb-python-client/pull/163

[RDBC-674](https://issues.hibernatingrhinos.com/issue/RDBC-674) Publish the Python serialize entities patch