### PR TITLE
Issue #172 - Removed 'reserved' characters from the quote_key method

### DIFF
--- a/ravendb/tests/issue_tests/test_issue_172.py
+++ b/ravendb/tests/issue_tests/test_issue_172.py
@@ -1,0 +1,21 @@
+from ravendb.tests.test_base import TestBase
+
+
+class TestIssue172(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_metadata(self):
+        with self.store.open_session() as ravendb_session:
+            ravendb_session.store({"a": 1}, "a+b")
+            ravendb_session.store({"b": 2}, "a-b")
+            ravendb_session.store({"c": 3}, "%:=&?~#+!$,;'*[]")
+            ravendb_session.save_changes()
+
+        with self.store.open_session() as session:
+            a = session.load("a+b")
+            b = session.load("a-b")
+            c = session.load("%:=&?~#+!$,;'*[]")
+            self.assertIsNotNone(a)
+            self.assertIsNotNone(b)
+            self.assertIsNotNone(c)

--- a/ravendb/tools/utils.py
+++ b/ravendb/tools/utils.py
@@ -354,7 +354,7 @@ class Utils(object):
 
     @staticmethod
     def quote_key(key, reserved_slash=False, reserved_at=False) -> str:
-        reserved = "%:=&?~#+!$,;'*[]"
+        reserved = ""
         if reserved_slash:
             reserved += "/"
         if reserved_at:


### PR DESCRIPTION
Loading documents with `+` sign in the document id has returned `None` values.
The cause was in the `quote_key`, `+` sign was considered safe, which resulted in an invalid URL.

https://github.com/ravendb/ravendb-python-client/issues/172