### PR TITLE
RDBC-706 Convert bytearray objects to bytes just before they're passed to the requests lib in the bulk insert operation

### DIFF
--- a/ravendb/documents/bulk_insert_operation.py
+++ b/ravendb/documents/bulk_insert_operation.py
@@ -36,7 +36,7 @@ class BulkInsertOperation:
             self.output_stream_mock = Future()
 
         def enqueue_buffer_for_flush(self, buffer: bytearray):
-            self._buffers_to_flush_queue.put(buffer)
+            self._buffers_to_flush_queue.put(bytes(buffer))
 
         # todo: blocking semaphore acquired and released on enter and exit from bulk insert operation context manager
         def send_data(self):


### PR DESCRIPTION
Full description in the issue:
https://issues.hibernatingrhinos.com/issue/RDBC-706/Bulk-insert-doesnt-work-in-the-python-client-or-is-killed-on-the-way