### PR TITLE
Updated ijson dependency to >= 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "requests >= 2.27.1",
         "requests-pkcs12 >= 1.13",
         "pyOpenSSL >= 22.0.0",
-        "ijson == 2.3",
+        "ijson >= 3",
         "websocket-client >= 0.46.0",
         "inflect >= 5.4.0",
     ],


### PR DESCRIPTION
Dear community,
we've run into problems using this library with other libraries that use other versions of ijson than 2.3 (see initial request [here](https://github.com/ravendb/ravendb-python-client/pull/71#issuecomment-1564119118)).

@poissoncorp has already created a [ticket](https://issues.hibernatingrhinos.com/issue/RDBC-718/Revert-fixed-ijson-version-and-update-it-to-the-current-one).

Luckily, the dependency is only used in one file and thus easy to update to newer version.

Thanks!