### PR TITLE
5.2.5 Post release 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="5.2.5",
+    version="5.2.5.post1",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
Handling release issues - previously published version 5.2.5 missed few files
matching embedded release - https://github.com/ravendb/ravendb-python-embedded/pull/12