### PR TITLE
RDBC-811, RDBC-809, RDBC-807, RDBC-750 - Breaking changes - new version 5.2.6 

### DIFF
--- a/ravendb/documents/commands/results.py
+++ b/ravendb/documents/commands/results.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Union, Optional, List, Dict
+from typing import Union, Optional, List, Dict, Any
 
 
 class GetDocumentResult:
@@ -39,3 +39,13 @@ class GetDocumentsResult:
             json_dict.get("CompareExchangeValueIncludes", None),
             json_dict.get("NextPageStart", None),
         )
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "Includes": self.includes,
+            "Results": self.results,
+            "CounterIncludes": self.counter_includes,
+            "TimeSeriesIncludes": self.time_series_includes,
+            "CompareExchangeValueIncludes": self.compare_exchange_includes,
+            "NextPageStart": self.next_page_start,
+        }

--- a/ravendb/documents/session/cluster_transaction_operation.py
+++ b/ravendb/documents/session/cluster_transaction_operation.py
@@ -50,12 +50,14 @@ class IClusterTransactionOperations(IClusterTransactionOperationsBase):
         pass
 
     @abc.abstractmethod
-    def get_compare_exchange_value(self, key: str, object_type: Type[_T] = None) -> Optional[CompareExchangeValue[_T]]:
+    def get_compare_exchange_value(
+        self, key: str, object_type: Optional[Type[_T]] = None
+    ) -> Optional[CompareExchangeValue[_T]]:
         pass
 
     @abc.abstractmethod
     def get_compare_exchange_values(
-        self, keys: List[str], object_type: Type[_T] = None
+        self, keys: List[str], object_type: Optional[Type[_T]] = None
     ) -> Dict[str, CompareExchangeValue[_T]]:
         pass
 
@@ -289,11 +291,13 @@ class ClusterTransactionOperations(ClusterTransactionOperationsBase, IClusterTra
     def lazily(self) -> ILazyClusterTransactionOperations:
         return LazyClusterTransactionOperations(self.session)
 
-    def get_compare_exchange_value(self, key: str, object_type: Type[_T] = None) -> Optional[CompareExchangeValue[_T]]:
+    def get_compare_exchange_value(
+        self, key: str, object_type: Optional[Type[_T]] = None
+    ) -> Optional[CompareExchangeValue[_T]]:
         return self._get_compare_exchange_value_internal(key, object_type)
 
     def get_compare_exchange_values(
-        self, keys: List[str], object_type: Type[_T] = None
+        self, keys: List[str], object_type: Optional[Type[_T]] = None
     ) -> Dict[str, CompareExchangeValue[_T]]:
         return super()._get_compare_exchange_values_internal(keys, object_type)
 

--- a/ravendb/documents/session/cluster_transaction_operation.py
+++ b/ravendb/documents/session/cluster_transaction_operation.py
@@ -55,7 +55,7 @@ class IClusterTransactionOperations(IClusterTransactionOperationsBase):
 
     @abc.abstractmethod
     def get_compare_exchange_values(
-        self, keys: List[str], object_type: Type[_T]
+        self, keys: List[str], object_type: Type[_T] = None
     ) -> Dict[str, CompareExchangeValue[_T]]:
         pass
 
@@ -293,7 +293,7 @@ class ClusterTransactionOperations(ClusterTransactionOperationsBase, IClusterTra
         return self._get_compare_exchange_value_internal(key, object_type)
 
     def get_compare_exchange_values(
-        self, keys: List[str], object_type: Type[_T]
+        self, keys: List[str], object_type: Type[_T] = None
     ) -> Dict[str, CompareExchangeValue[_T]]:
         return super()._get_compare_exchange_values_internal(keys, object_type)
 

--- a/ravendb/documents/session/document_session.py
+++ b/ravendb/documents/session/document_session.py
@@ -725,7 +725,7 @@ class DocumentSession(InMemoryDocumentSessionOperations):
             return self._session._lazily
 
         def graph_query(self, object_type: type, query: str):  # -> GraphDocumentQuery:
-            pass
+            raise NotImplementedError("Dropped support for graph queries")
 
         def what_changed(self) -> Dict[str, List[DocumentsChanges]]:
             return self._session._what_changed()

--- a/ravendb/documents/session/document_session.py
+++ b/ravendb/documents/session/document_session.py
@@ -375,16 +375,30 @@ class DocumentSession(InMemoryDocumentSessionOperations):
         start_after: Optional[str] = None,
     ) -> List[_T]:
         load_starting_with_operation = LoadStartingWithOperation(self)
-        self.__load_starting_with_internal(
-            id_prefix, load_starting_with_operation, None, matches, start, page_size, exclude, start_after
+        self._load_starting_with_internal(
+            id_prefix, load_starting_with_operation, matches, start, page_size, exclude, start_after
         )
         return load_starting_with_operation.get_documents(object_type)
 
-    def __load_starting_with_internal(
+    def load_starting_with_into_stream(
+        self,
+        id_prefix: str,
+        matches: str = None,
+        start: int = 0,
+        page_size: int = 25,
+        exclude: str = None,
+        start_after: str = None,
+    ) -> bytes:
+        if id_prefix is None:
+            raise ValueError("Arg 'id_prefix' is cannot be None.")
+        return self._load_starting_with_into_stream_internal(
+            id_prefix, LoadStartingWithOperation(self), matches, start, page_size, exclude, start_after
+        )
+
+    def _load_starting_with_internal(
         self,
         id_prefix: str,
         operation: LoadStartingWithOperation,
-        stream,
         matches: str,
         start: int,
         page_size: int,
@@ -395,11 +409,30 @@ class DocumentSession(InMemoryDocumentSessionOperations):
         command = operation.create_request()
         if command:
             self._request_executor.execute_command(command, self.session_info)
-            if stream:
-                pass  # todo: stream
-            else:
-                operation.set_result(command.result)
+            operation.set_result(command.result)
         return command
+
+    def _load_starting_with_into_stream_internal(
+        self,
+        id_prefix: str,
+        operation: LoadStartingWithOperation,
+        matches: str,
+        start: int,
+        page_size: int,
+        exclude: str,
+        start_after: str,
+    ) -> bytes:
+        operation.with_start_with(id_prefix, matches, start, page_size, exclude, start_after)
+        command = operation.create_request()
+        bytes_result = None
+        if command:
+            self.request_executor.execute_command(command, self.session_info)
+            try:
+                result = command.result
+                bytes_result = json.dumps(result.to_json()).encode("utf-8")
+            except Exception as e:
+                raise RuntimeError("Unable sto serialize returned value into stream") from e
+        return bytes_result
 
     def document_query_from_index_type(self, index_type: Type[_TIndex], object_type: Type[_T]) -> DocumentQuery[_T]:
         try:
@@ -783,32 +816,6 @@ class DocumentSession(InMemoryDocumentSessionOperations):
 
             index_options.wait_for_indexes = True
 
-        def __load_starting_with_internal(
-            self,
-            id_prefix: str,
-            operation: LoadStartingWithOperation,
-            stream: Union[None, bytes],
-            matches: str,
-            start: int,
-            page_size: int,
-            exclude: str,
-            start_after: str,
-        ) -> GetDocumentsCommand:
-            operation.with_start_with(id_prefix, matches, start, page_size, exclude, start_after)
-            command = operation.create_request()
-            if command is not None:
-                self._session._request_executor.execute(command, self._session.session_info)
-                if stream:
-                    try:
-                        result = command.result
-                        stream_to_dict = json.loads(stream.decode("utf-8"))
-                        result.__dict__.update(stream_to_dict)
-                    except IOError as e:
-                        raise RuntimeError(f"Unable to serialize returned value into stream {e.args[0]}", e)
-                else:
-                    operation.set_result(command.result)
-            return command
-
         def load_starting_with(
             self,
             id_prefix: str,
@@ -826,26 +833,14 @@ class DocumentSession(InMemoryDocumentSessionOperations):
         def load_starting_with_into_stream(
             self,
             id_prefix: str,
-            output: bytes,
             matches: str = None,
             start: int = 0,
             page_size: int = 25,
             exclude: str = None,
             start_after: str = None,
-        ):
-            if not output:
-                raise ValueError("Output cannot be None")
-            if not id_prefix:
-                raise ValueError("Id prefix cannot be None")
-            self.__load_starting_with_internal(
-                id_prefix,
-                LoadStartingWithOperation(self._session),
-                output,
-                matches,
-                start,
-                page_size,
-                exclude,
-                start_after,
+        ) -> bytes:
+            return self._session.load_starting_with_into_stream(
+                id_prefix, matches, start, page_size, exclude, start_after
             )
 
         def load_into_stream(self, keys: List[str], output: bytes) -> None:

--- a/ravendb/documents/session/document_session.py
+++ b/ravendb/documents/session/document_session.py
@@ -456,6 +456,8 @@ class DocumentSession(InMemoryDocumentSessionOperations):
         return SessionDocumentCounters(self, entity)
 
     def time_series_for(self, document_id: str, name: str = None) -> SessionDocumentTimeSeries:
+        if not isinstance(document_id, str):
+            raise TypeError("Method time_series_for expects a string. Did you want to call time_series_for_entity?")
         return SessionDocumentTimeSeries(self, document_id, name)
 
     def time_series_for_entity(self, entity: object, name: str = None) -> SessionDocumentTimeSeries:

--- a/ravendb/documents/session/loaders/include.py
+++ b/ravendb/documents/session/loaders/include.py
@@ -358,23 +358,29 @@ class SubscriptionIncludeBuilder(IncludeBuilderBase):
         self._include_all_counters("")
         return self
 
+    def include_time_series_by_range_type_and_time(
+        self, name: str, ts_type: TimeSeriesRangeType, time: TimeValue
+    ) -> SubscriptionIncludeBuilder:
+        self._include_time_series_by_range_type_and_time("", name, ts_type, time)
+        return self
 
-#   def include_time_series(
-#       self,
-#       name:str,
-#       ts_type: TimeSeriesRangeType,
-#       time: TimeValue
-#   ) -> SubscriptionIncludeBuilder:
-#        self._include_time_series_by_range_type_and_time("", name, ts_type, time)
-#        return self
-#
-#   def include_time_series_by_range_type_and_count(
-#       self,
-#       name:str,
-#       ts_type: TimeSeriesRangeType,
-#       time: TimeValue
-#   ) -> SubscriptionIncludeBuilder:
-#       self._include_time_series_by_range_type_and_count("", name, type, count)
+    def include_time_series_by_range_type_and_count(
+        self, name: str, ts_type: TimeSeriesRangeType, count: int
+    ) -> SubscriptionIncludeBuilder:
+        self._include_time_series_by_range_type_and_count("", name, ts_type, count)
+        return self
+
+    def include_all_time_series_by_range_type_and_count(
+        self, ts_type: TimeSeriesRangeType, count: int
+    ) -> SubscriptionIncludeBuilder:
+        self._include_time_series_by_range_type_and_count("", constants.TimeSeries.ALL, ts_type, count)
+        return self
+
+    def include_all_time_series_by_range_type_and_time(
+        self, ts_type: TimeSeriesRangeType, time: TimeValue
+    ) -> SubscriptionIncludeBuilder:
+        self._include_time_series_by_range_type_and_time("", constants.TimeSeries.ALL, ts_type, time)
+        return self
 
 
 class TimeSeriesIncludeBuilder(IncludeBuilderBase):

--- a/ravendb/documents/session/loaders/loaders.py
+++ b/ravendb/documents/session/loaders/loaders.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import abstractmethod
-from typing import TypeVar, TYPE_CHECKING, Dict, List, Type
+from typing import TypeVar, TYPE_CHECKING, Dict, List, Type, Optional, Set, Union
 
 from ravendb.documents.store.lazy import Lazy
 
@@ -16,21 +16,24 @@ class LoaderWithInclude:
         pass
 
     @abstractmethod
-    def load(self, object_type: _T, *ids: str) -> _T:
+    def load(self, id_: str, object_type: Optional[Type[_T]] = None) -> _T:
         pass
 
 
 class MultiLoaderWithInclude(LoaderWithInclude):
     def __init__(self, session: DocumentSession):
         self.__session = session
-        self.__includes: List[str] = []
+        self.__includes: Set[str] = set()
 
     def include(self, path: str) -> LoaderWithInclude:
-        self.__includes.append(path)
+        self.__includes.add(path)
         return self
 
-    def load(self, object_type: Type[_T], *ids: str) -> Dict[str, _T]:
-        return self.__session._load_internal(object_type, list(ids), self.__includes)
+    def load(self, id_or_ids: Union[List[str], str], object_type: Optional[Type[_T]] = None) -> _T:
+        if not isinstance(id_or_ids, (str, list)):
+            raise TypeError(f"Expected str or list of str, got '{type(id_or_ids)}'")
+        ids = [id_or_ids] if isinstance(id_or_ids, str) else id_or_ids
+        return self.__session._load_internal(object_type, ids, self.__includes)
 
 
 class LazyMultiLoaderWithInclude(LoaderWithInclude):
@@ -42,5 +45,8 @@ class LazyMultiLoaderWithInclude(LoaderWithInclude):
         self.__includes.append(path)
         return self
 
-    def load(self, object_type: Type[_T], *ids: str) -> Lazy[Dict[str, _T]]:
-        return self.__session.lazy_load_internal(object_type, list(ids), self.__includes, None)
+    def load(self, id_or_ids: Union[List[str], str], object_type: Optional[Type[_T]] = None) -> Lazy[Dict[str, _T]]:
+        if not isinstance(id_or_ids, (str, list)):
+            raise TypeError(f"Expected str or list of str, got '{type(id_or_ids)}'")
+        ids = [id_or_ids] if isinstance(id_or_ids, str) else id_or_ids
+        return self.__session.lazy_load_internal(object_type, ids, self.__includes, None)

--- a/ravendb/documents/session/operations/lazy.py
+++ b/ravendb/documents/session/operations/lazy.py
@@ -189,7 +189,7 @@ class LazySessionOperations:
         return LazyMultiLoaderWithInclude(self._delegate).include(path)
 
     def load(
-        self, object_type: Type[_T], ids: Union[List[str], str], on_eval: Callable = None
+        self, ids: Union[List[str], str], object_type: Type[_T], on_eval: Callable = None
     ) -> Optional[Lazy[Union[Dict[str, object], object]]]:
         if not ids:
             return None
@@ -208,12 +208,12 @@ class LazySessionOperations:
         elif isinstance(ids, list):
             return self._delegate.lazy_load_internal(object_type, ids, [], on_eval)
 
-        raise TypeError("Expected 'ids' as 'str' or 'list[str]'")
+        raise TypeError(f"Expected a 'str' or 'list' of 'str', the document ids. Got '{type(ids).__name__}'.")
 
     def load_starting_with(
         self,
         id_prefix: str,
-        object_type: Optional[Type[_T]],
+        object_type: Optional[Type[_T]] = None,
         matches: str = None,
         start: int = 0,
         page_size: int = 25,

--- a/ravendb/documents/subscriptions/document_subscriptions.py
+++ b/ravendb/documents/subscriptions/document_subscriptions.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional, Type, TypeVar, Dict, List, TYPE_CHECKING
 
 from ravendb.documents.operations.ongoing_tasks import ToggleOngoingTaskStateOperation, OngoingTaskType
+from ravendb.documents.session.tokens.query_tokens.definitions import CounterIncludesToken, TimeSeriesIncludesToken
 from ravendb.documents.session.tokens.query_tokens.query_token import QueryToken
 from ravendb.documents.session.utils.includes_util import IncludesUtil
 from ravendb.documents.commands.subscriptions import (
@@ -96,11 +97,11 @@ class DocumentSubscriptions:
 
             number_of_includes_added = 0
 
-            if builder._documents_to_include is not None and not len(builder._documents_to_include) == 0:
+            if builder.documents_to_include is not None and not len(builder.documents_to_include) == 0:
                 query_builder.append(os.linesep)
                 query_builder.append("include ")
 
-                for inc in builder._documents_to_include:
+                for inc in builder.documents_to_include:
                     include = "doc." + inc
                     if number_of_includes_added > 0:
                         query_builder.append(",")
@@ -115,41 +116,41 @@ class DocumentSubscriptions:
                         query_builder.append(f"'{include}'" if QueryToken.is_keyword(include) else include)
 
                     number_of_includes_added += 1
-            # todo: uncomment on Counters and TimeSeries development
-            # if builder._is_all_counters:
-            #     if number_of_includes_added == 0:
-            #         query_builder.append(os.linesep)
-            #         query_builder.append("include ")
-            #
-            #     token = CountersIncludesToken.all("")
-            #     token.write_to(query_builder)
-            #     number_of_includes_added += 1
-            #
-            # elif builder._counters_to_include:
-            #     if number_of_includes_added:
-            #         query_builder.append(os.linesep)
-            #         query_builder.append("include ")
-            #
-            #     for counter_name in builder._counters_to_include:
-            #         if number_of_includes_added > 0:
-            #             query_builder.append(",")
-            #
-            #         token = CountersToIncludeToken.create("", counter_name)
-            #         token.write_to(query_builder)
-            #
-            #         number_of_includes_added += 1
-            #
-            # if builder._time_series_to_include:
-            #     for time_series_range in builder._time_series_to_include:
-            #         if number_of_includes_added == 0:
-            #             query_builder.append(os.linesep)
-            #             query_builder.append("include ")
-            #
-            #         if number_of_includes_added > 0:
-            #             query_builder.append(",")
-            #
-            #         token = TimeSeriesIncludeToken.create("", time_series_range)
-            #         token.write_to(query_builder)
+
+            if builder.is_all_counters:
+                if number_of_includes_added == 0:
+                    query_builder.append(os.linesep)
+                    query_builder.append("include ")
+
+                token = CounterIncludesToken.all("")
+                token.write_to(query_builder)
+                number_of_includes_added += 1
+
+            elif builder.counters_to_include:
+                if number_of_includes_added:
+                    query_builder.append(os.linesep)
+                    query_builder.append("include ")
+
+                for counter_name in builder.counters_to_include:
+                    if number_of_includes_added > 0:
+                        query_builder.append(",")
+
+                    token = CounterIncludesToken.create("", counter_name)
+                    token.write_to(query_builder)
+
+                    number_of_includes_added += 1
+
+            if builder.time_series_to_include:
+                for time_series_range in builder.time_series_to_include:
+                    if number_of_includes_added == 0:
+                        query_builder.append(os.linesep)
+                        query_builder.append("include ")
+
+                    if number_of_includes_added > 0:
+                        query_builder.append(",")
+
+                    token = TimeSeriesIncludesToken.create("", time_series_range)
+                    token.write_to(query_builder)
 
         criteria.query = "".join(query_builder)
         return criteria

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 class RequestExecutor:
     __INITIAL_TOPOLOGY_ETAG = -2
     __GLOBAL_APPLICATION_IDENTIFIER = uuid.uuid4()
-    CLIENT_VERSION = "5.2.5"
+    CLIENT_VERSION = "5.2.6"
     logger = logging.getLogger("request_executor")
 
     # todo: initializer should take also cryptography certificates

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -129,7 +129,8 @@ class RequestExecutor:
             self.__update_topology_timer.cancel()
 
         self._dispose_all_failed_nodes_timers()
-        self.__http_session.close()
+        if self.__http_session is not None:
+            self.__http_session.close()
 
     @property
     def certificate_path(self) -> str:
@@ -169,7 +170,6 @@ class RequestExecutor:
         return self.__http_session
 
     def __create_http_session(self) -> requests.Session:
-        # todo: check if http client name is required
         session = requests.session()
         session.cert = self.__certificate_path
         session.verify = self.__trust_store_path if self.__trust_store_path else True

--- a/ravendb/tests/jvm_migrated_tests/bugs_tests/caching_tests/test_caching_of_document_include.py
+++ b/ravendb/tests/jvm_migrated_tests/bugs_tests/caching_tests/test_caching_of_document_include.py
@@ -43,7 +43,7 @@ class CachingOfDocumentsIncludeTest(TestBase):
             session.load(user.partner_id)
 
             old = session.number_of_requests
-            new_user = session.include("partner_id").load(User, "users/2-A")
+            new_user = session.include("partner_id").load(["users/2-A"])
             self.assertEqual(old, session.number_of_requests)
 
     def test_can_include_nested_paths(self):

--- a/ravendb/tests/jvm_migrated_tests/client_tests/revisions_tests/test_revisions.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/revisions_tests/test_revisions.py
@@ -356,7 +356,7 @@ class TestRevisions(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            revision = session.advanced.lazily.load(User, "users/1")
+            revision = session.advanced.lazily.load("users/1", User)
             doc = revision.value
             self.assertEqual(1, session.advanced.number_of_requests)
 

--- a/ravendb/tests/jvm_migrated_tests/client_tests/test_load_into_stream.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/test_load_into_stream.py
@@ -1,0 +1,40 @@
+import json
+
+from ravendb import DocumentStore
+from ravendb.documents.commands.results import GetDocumentsResult
+from ravendb.infrastructure.orders import Employee
+from ravendb.tests.test_base import TestBase
+
+
+class TestLoadIntoStream(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    @staticmethod
+    def insert_data(store: DocumentStore):
+        with store.open_session() as session:
+
+            def _insert_employee(name: str = None):
+                employee = Employee(first_name=name)
+                session.store(employee)
+
+            _insert_employee("Aviv")
+            _insert_employee("Iftah")
+            _insert_employee("Tal")
+            _insert_employee("Maxim")
+            _insert_employee("Karmel")
+            _insert_employee("Grisha")
+            _insert_employee("Michael")
+            session.save_changes()
+
+    def test_can_load_starting_with_into_stream(self):
+        self.insert_data(self.store)
+        with self.store.open_session() as session:
+            stream = session.advanced.load_starting_with_into_stream("employees/")
+            json_node = json.loads(stream.decode("utf-8"))
+            result = GetDocumentsResult.from_json(json_node)
+            self.assertEqual(7, len(result.results))
+            names = ["Aviv", "Iftah", "Tal", "Maxim", "Karmel", "Grisha", "Michael"]
+            for name_from_results in [result["first_name"] for result in result.results]:
+                self.assertIn(name_from_results, names)
+                names.remove(name_from_results)

--- a/ravendb/tests/jvm_migrated_tests/issues_tests/test_ravenDB_15826.py
+++ b/ravendb/tests/jvm_migrated_tests/issues_tests/test_ravenDB_15826.py
@@ -23,9 +23,9 @@ class TestRavenDB15826(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            session.include("refs").load(Item, "items/d")  # include, some loaded
+            session.include("refs").load("items/d", Item)  # include, some loaded
             a: Item = session.load("items/c", Item)
-            items = session.advanced.lazily.load(Item, a.refs)
+            items = session.advanced.lazily.load(a.refs, Item)
             session.advanced.eagerly.execute_all_pending_lazy_operations()
             items_map = items.value
             self.assertEqual(len(items_map), len(a.refs))

--- a/ravendb/tests/jvm_migrated_tests/lazy_tests/test_lazy.py
+++ b/ravendb/tests/jvm_migrated_tests/lazy_tests/test_lazy.py
@@ -17,13 +17,13 @@ class TestLazy(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            lazy_order = session.advanced.lazily.load(Company, "companies/1")
+            lazy_order = session.advanced.lazily.load("companies/1", Company)
             self.assertFalse(lazy_order.is_value_created)
 
             order: Company = lazy_order.value
             self.assertEqual("companies/1", order.Id)
 
-            lazy_orders = session.advanced.lazily.load(Company, ["companies/1", "companies/2"])
+            lazy_orders = session.advanced.lazily.load(["companies/1", "companies/2"], Company)
             self.assertFalse(lazy_orders.is_value_created)
 
             orders: Dict[str, Company] = lazy_orders.value
@@ -38,7 +38,7 @@ class TestLazy(TestBase):
             self.assertEqual("companies/1", company1.Id)
             self.assertEqual("companies/2", company2.Id)
 
-            lazy_order = session.advanced.lazily.load(Company, "companies/3")
+            lazy_order = session.advanced.lazily.load("companies/3", Company)
 
             self.assertFalse(lazy_order.is_value_created)
 
@@ -46,7 +46,7 @@ class TestLazy(TestBase):
 
             self.assertEqual("companies/3", order.Id)
 
-            load = session.advanced.lazily.load(Company, ["no_such_1", "no_such_2"])
+            load = session.advanced.lazily.load(["no_such_1", "no_such_2"], Company)
             missing_itmes = load.value
 
             self.assertIsNone(missing_itmes.get("no_such_1"))
@@ -59,10 +59,10 @@ class TestLazy(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            session.advanced.lazily.load(User, "users/1").value
+            session.advanced.lazily.load("users/1", User).value
             old_request_count = session.number_of_requests
 
-            user: User = session.advanced.lazily.load(User, "users/1").value
+            user: User = session.advanced.lazily.load("users/1", User).value
             self.assertEqual("Oren", user.name)
 
             self.assertEqual(old_request_count, session.number_of_requests)
@@ -87,8 +87,8 @@ class TestLazy(TestBase):
 
                 return __inner
 
-            session.advanced.lazily.load(Company, "companies/1", lambda x: __fun(company1ref)(x))
-            session.advanced.lazily.load(Company, "companies/2", lambda x: __fun(company2ref)(x))
+            session.advanced.lazily.load("companies/1", Company, lambda x: __fun(company1ref)(x))
+            session.advanced.lazily.load("companies/2", Company, lambda x: __fun(company2ref)(x))
 
             self.assertEqual(0, len(company1ref))
             self.assertEqual(0, len(company2ref))
@@ -113,7 +113,7 @@ class TestLazy(TestBase):
             def __fun(x):
                 user_ref.append(x)
 
-            session.advanced.lazily.load(User, "users/1", lambda x: __fun(x))
+            session.advanced.lazily.load("users/1", User, lambda x: __fun(x))
 
             session.advanced.eagerly.execute_all_pending_lazy_operations()
 
@@ -133,8 +133,8 @@ class TestLazy(TestBase):
             session.save_changes()
 
         with self.store.open_session() as session:
-            lazy_load = session.advanced.lazily.load(User, ["users/2", "users/3"])
-            session.advanced.lazily.load(User, ["users/1", "users/3"])
+            lazy_load = session.advanced.lazily.load(["users/2", "users/3"], User)
+            session.advanced.lazily.load(["users/1", "users/3"], User)
 
             session.load("users/2", User)
             session.load("users/3", User)
@@ -147,7 +147,7 @@ class TestLazy(TestBase):
             self.assertEqual(2, len(users))
 
             old_request_count = session.number_of_requests
-            lazy_load = session.advanced.lazily.load(User, ["users/3"])
+            lazy_load = session.advanced.lazily.load(["users/3"], User)
             session.advanced.eagerly.execute_all_pending_lazy_operations()
 
             self.assertEqual(old_request_count, session.number_of_requests)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="5.2.5.post1",
+    version="5.2.6",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
Bundled all currently planned breaking changes - needed for documentation

https://issues.hibernatingrhinos.com/issue/RDBC-811/Make-loadstartingwithintostream-work-properly
https://issues.hibernatingrhinos.com/issue/RDBC-750/Inconsistent-API-design-issues-within-lazy-loads-and-includes
https://issues.hibernatingrhinos.com/issue/RDBC-809/Method-getcompareexchangevalues-cant-require-objecttype-set-as-optional

\+ https://issues.hibernatingrhinos.com/issue/RDBC-807/Handle-None-in-RequestExecutor.httpsession

1. RDBC-809 Get compare exchange values - Set object_type as optional, no need to provide it
```py
 def get_compare_exchange_values(
        self, keys: List[str], object_type: Type[_T]
    ) -> Dict[str, CompareExchangeValue[_T]]:
        pass
```
changed to
```py
 def get_compare_exchange_values(
        self, keys: List[str], object_type: Optional[Type[_T]] = None
    ) -> Dict[str, CompareExchangeValue[_T]]:
        pass
```

2. RDBC-811 Load starting with into stream - Fixed, changed signature - it doesn't take any stream/output bytes arg, it returns bytes instead
```py
def load_starting_with_into_stream(
        self,
        id_prefix: str,
        matches: str = None,
        start: int = 0,
        page_size: int = 25,
        exclude: str = None,
        start_after: str = None,
    ) -> bytes:
```
3. RDBC-750 lazily.load() and include().load()
```py
# -----------
lazily.load()
# -----------
def load(self, object_type: Type[_T], *ids: str) -> Lazy[Dict[str, _T]]:
# -->
def load(self, id_or_ids: Union[List[str], str], object_type: Optional[Type[_T]] = None) -> Lazy[Dict[str, _T]]:

# -----------
include(...).load()
# -----------
 def load(self, object_type: Type[_T], ids: Union[List[str], str], on_eval: Callable = None) -> Optional[Lazy[Union[Dict[str, object], object]]]:
# --->
 def load(self, ids: Union[List[str], str], object_type: Type[_T], on_eval: Callable = None) -> Optional[Lazy[Union[Dict[str, object], object]]]:
```
