### PR TITLE
RDBC-812 Don't send 'Id' property to the server

### DIFF
--- a/ravendb/documents/identity/hilo.py
+++ b/ravendb/documents/identity/hilo.py
@@ -46,7 +46,7 @@ class GenerateEntityIdOnTheClient:
         self.__try_set_identity_internal(entity, key, is_projection)
 
     def __try_set_identity_internal(self, entity: Union[object, dict], key: str, is_projection: bool = False) -> None:
-        identity_property = "Id"  # todo: make sure it's ok, create get_identity_property...
+        identity_property = "Id"  # todo: get_identity_property...
 
         if identity_property is None:
             return
@@ -55,7 +55,7 @@ class GenerateEntityIdOnTheClient:
             # identity property was already set
             return
 
-        if type(entity) == dict:
+        if isinstance(entity, dict):
             entity[identity_property] = key
             return
         entity.__setattr__(identity_property, key)

--- a/ravendb/documents/session/entity_to_json.py
+++ b/ravendb/documents/session/entity_to_json.py
@@ -38,7 +38,7 @@ class EntityToJson:
             self._session.before_conversion_to_document_invoke(
                 BeforeConversionToDocumentEventArgs(document_info.key, entity, self._session)
             )
-        document = EntityToJson._convert_entity_to_json_internal(self, entity, document_info)
+        document = EntityToJson._convert_entity_to_json_internal(self, entity, document_info, True)
         if document_info is not None:
             self._session.after_conversion_to_document_invoke(
                 AfterConversionToDocumentEventArgs(self._session, document_info.key, entity, document)

--- a/ravendb/documents/session/entity_to_json.py
+++ b/ravendb/documents/session/entity_to_json.py
@@ -192,9 +192,10 @@ class EntityToJson:
                 BeforeConversionToEntityEventArgs(session_hook, key, object_type, document_deepcopy)
             )
 
-        # 1.1 Check if passed object type (or extracted from metadata) is a dictionary
-        if object_type == dict or type_from_metadata == "builtins.dict":
+        # 1.1 Check if passed object type (or extracted from metadata) is a dictionary and if document isn't a dict
+        if object_type == dict or (object_type is None and type_from_metadata == "builtins.dict"):
             EntityToJson._invoke_after_conversion_to_entity_event(session_hook, key, object_type, document_deepcopy)
+            # todo: document_deepcopy["Id"] = metadata.get("@id", None) - consider adding id property
             return document_deepcopy
 
         # 1.2 If there's no object type in metadata
@@ -211,8 +212,12 @@ class EntityToJson:
         # 2. There was a type in the metadata
         else:
             object_from_metadata = Utils.import_class(type_from_metadata)
+
+            # 2.0 Check if the user wants to cast dict to type
+            if object_from_metadata == dict and object_type != dict:
+                pass
             # 2.1 Import was successful
-            if object_from_metadata is not None:
+            elif object_from_metadata is not None:
                 # 2.1.1 Set object_type to successfully imported type/ from metadata inherits from passed object_type
                 if object_type is None or Utils.is_inherit(object_type, object_from_metadata):
                     object_type = object_from_metadata

--- a/ravendb/tests/issue_tests/test_issue_198.py
+++ b/ravendb/tests/issue_tests/test_issue_198.py
@@ -1,3 +1,5 @@
+from ravendb.infrastructure.orders import Company
+from ravendb.primitives import constants
 from ravendb.tests.test_base import TestBase
 
 
@@ -22,6 +24,28 @@ class TestIssue198(TestBase):
         with self.store.open_session() as session:
             product = session.load(guid_from_server)
             self.assertEqual("Test", product.name)
+            metadata_id = session.advanced.get_metadata_for(product)["@id"]
+            identity = session.advanced.get_document_id(product)
+            id_prop = product.Id
+
+            self.assertEqual(id_prop, identity)
+            self.assertEqual(id_prop, metadata_id)
+            self.assertEqual(id_prop, guid_from_server)
+
+        with self.store.open_session() as session:
+            product = session.load(guid_from_server)
+            product.Id = ""
+            session.save_changes()
+
+        with self.store.open_session() as session:
+            product = session.load(guid_from_server)
+            metadata_id1 = session.advanced.get_metadata_for(product)[constants.Documents.Metadata.ID]
+            identity1 = session.advanced.get_document_id(product)
+            id_prop1 = product.Id
+
+            self.assertEqual(id_prop, id_prop1)
+            self.assertEqual(id_prop, metadata_id1)
+            self.assertEqual(id_prop, identity1)
 
     def test_can_create_multiple_documents_with_server_generated_guid(self):
         with self.store.open_session() as session:
@@ -45,3 +69,14 @@ class TestIssue198(TestBase):
 
             product3 = session.load(guid_from_server3)
             self.assertEqual("Test3", product3.name)
+
+    def test_preserve_id_field(self):
+        with self.store.open_session() as session:
+            company = Company(Id="companies/222", name="Apple Inc.")
+            session.store(company)
+            session.save_changes()
+
+        with self.store.open_session() as session:
+            company = session.load("companies/222", Company)
+            self.assertEqual("companies/222", company.Id)
+            self.assertEqual("Apple Inc.", company.name)

--- a/ravendb/tests/jvm_migrated_tests/crud_tests/test_basic_document.py
+++ b/ravendb/tests/jvm_migrated_tests/crud_tests/test_basic_document.py
@@ -13,7 +13,7 @@ class TestBasicDocument(TestBase):
         super(TestBasicDocument, self).setUp()
 
     def test_get(self):
-        dummy = {"name": None, "age": None, "Id": None}
+        dummy = {"name": None, "age": None}
         with self.store.open_session() as session:
             user1 = User("jacus", None)
             user2 = User("arek", None)

--- a/ravendb/tests/jvm_migrated_tests/issues_tests/test_RDBC_387.py
+++ b/ravendb/tests/jvm_migrated_tests/issues_tests/test_RDBC_387.py
@@ -25,5 +25,5 @@ class TestRDBC387(TestBase):
             self.assertIsNone(session_user.get("id", None))
             self.assertIsNone(bulk_insert_user.get("id", None))
 
-            self.assertIsNotNone(session_user.get("Id", None))
+            self.assertIsNone(session_user.get("Id", None))
             self.assertIsNone(bulk_insert_user.get("Id", None))

--- a/ravendb/tests/jvm_migrated_tests/server_tests/patching/test_advanced_patching.py
+++ b/ravendb/tests/jvm_migrated_tests/server_tests/patching/test_advanced_patching.py
@@ -46,7 +46,7 @@ class CustomType:
     @classmethod
     def from_json(cls, json_dict: Dict[str, Any]) -> CustomType:
         return cls(
-            json_dict["Id"],
+            json_dict["Id"] if "Id" in json_dict else None,
             json_dict["owner"],
             json_dict["value"],
             json_dict["comments"],

--- a/ravendb/tools/utils.py
+++ b/ravendb/tools/utils.py
@@ -450,7 +450,16 @@ class Utils(object):
     @staticmethod
     def initialize_object(obj: dict, object_type: Type[_T], convert_to_snake_case: bool = None) -> _T:
         initialize_dict, set_needed = Utils.make_initialize_dict(obj, object_type.__init__, convert_to_snake_case)
-        o = object_type(**initialize_dict)
+        try:
+            o = object_type(**initialize_dict)
+        except Exception as e:
+            if "Id" not in initialize_dict:
+                initialize_dict["Id"] = None
+                o = object_type(**initialize_dict)
+            else:
+                raise TypeError(
+                    f"Couldn't initialize object of type '{object_type.__name__}' using dict '{obj}'"
+                ) from e
         if set_needed:
             for key, value in obj.items():
                 setattr(o, key, value)


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-812/Dont-send-Id-property-to-the-server
https://github.com/ravendb/ravendb-python-client/issues/209

**Breaking Change:**
- Id property won't be stored at the server any more

**Implications:**
- Document id is still available as a value of the `Id` property, but the value is set after serialization
- Documents loaded as `dict` objects won't contain the `Id` key (still available via `session.advanced.get_metadata_for(...)["@id"]` or `session.advanced.get_document_id()`)
- Custom from_json methods that have been setting the Id property should skip that step, as the Id property will be set to a valid value after the serialization
