### PR TITLE
RDBC-800 Investigate failing tests on python >= 3.8 due to invalid code format

### DIFF
--- a/.git-blame.ignore-revs
+++ b/.git-blame.ignore-revs
@@ -1,0 +1,3 @@
+
+# run updated 'black' formatter on 3.8 Python
+4237c1a5f3a1e434c61e86419bea9901f90c6426

--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -29,7 +29,7 @@ jobs:
 
       strategy:
         matrix:
-          python-version: [ '3.7', '3.8', '3.9' , '3.10']
+          python-version: [ '3.7', '3.8', '3.10' ,'3.11', '3.12']
           serverVersion: [ "5.2", "5.4", "6.0" ]
         fail-fast: false
 
@@ -82,9 +82,11 @@ jobs:
         run: mkdir RavenDB/Server/certs && cp certs/server.pfx RavenDB/Server/certs/
 
       - name: Install black linter
+        if: ${{ matrix.python-version != '3.7' }}
         run: pip install black
 
       - name: Check code format
+        if: ${{ matrix.python-version != '3.7' }}
         run: black --check .
 
       - name: Run tests

--- a/ravendb/data/query.py
+++ b/ravendb/data/query.py
@@ -104,9 +104,9 @@ class OldIndexQuery(IndexQueryBase):
         if self.wait_for_non_stale_results_timeout is not None:
             data["WaitForNonStaleResultsTimeout"] = Utils.timedelta_to_str(self.wait_for_non_stale_results_timeout)
         if self.allow_multiple_index_entries_for_same_document_to_result_transformer:
-            data[
-                "AllowMultipleIndexEntriesForSameDocumentToResultTransformer"
-            ] = self.allow_multiple_index_entries_for_same_document_to_result_transformer
+            data["AllowMultipleIndexEntriesForSameDocumentToResultTransformer"] = (
+                self.allow_multiple_index_entries_for_same_document_to_result_transformer
+            )
         if self.show_timings:
             data["ShowTimings"] = self.show_timings
         if self.skip_duplicate_checking:

--- a/ravendb/documents/conventions.py
+++ b/ravendb/documents/conventions.py
@@ -65,9 +65,9 @@ class DocumentConventions(object):
         self._find_identity_property = lambda q: q.__name__ == "key"
         self._find_python_class: Optional[Callable[[str, Dict], str]] = None
         self._find_collection_name: Callable[[Type], str] = self.default_get_collection_name
-        self._find_python_class_name: Callable[
-            [Type], str
-        ] = lambda object_type: f"{object_type.__module__}.{object_type.__name__}"
+        self._find_python_class_name: Callable[[Type], str] = (
+            lambda object_type: f"{object_type.__module__}.{object_type.__name__}"
+        )
         self._transform_class_collection_name_to_document_id_prefix = (
             lambda collection_name: self.default_transform_collection_name_to_document_id_prefix(collection_name)
         )

--- a/ravendb/documents/indexes/definitions.py
+++ b/ravendb/documents/indexes/definitions.py
@@ -248,9 +248,9 @@ class IndexDefinition(IndexDefinitionBase):
             "State": self.state,
             "LockMode": self.lock_mode,
             "AdditionalSources": self.additional_sources,
-            "AdditionalAssemblies": [x.to_json() for x in self.additional_assemblies]
-            if self.additional_assemblies
-            else None,
+            "AdditionalAssemblies": (
+                [x.to_json() for x in self.additional_assemblies] if self.additional_assemblies else None
+            ),
             "Maps": self.maps,
             "Fields": {key: value.to_json() for key, value in self.fields.items()},
             "Reduce": self.reduce,

--- a/ravendb/documents/operations/backups/settings.py
+++ b/ravendb/documents/operations/backups/settings.py
@@ -227,9 +227,11 @@ class AzureSettings(BackupSettings):
     def from_json(cls, json_dict: Dict[str, Any]) -> AzureSettings:
         return cls(
             json_dict["Disabled"],
-            GetBackupConfigurationScript.from_json(json_dict["GetBackupConfigurationScript"])
-            if json_dict["GetBackupConfigurationScript"]
-            else None,
+            (
+                GetBackupConfigurationScript.from_json(json_dict["GetBackupConfigurationScript"])
+                if json_dict["GetBackupConfigurationScript"]
+                else None
+            ),
             json_dict["StorageContainer"],
             json_dict["RemoteFolderName"],
             json_dict["AccountName"],
@@ -240,9 +242,9 @@ class AzureSettings(BackupSettings):
     def to_json(self) -> Dict[str, Any]:
         return {
             "Disabled": self.disabled,
-            "GetBackupConfigurationScript": self.get_backup_configuration_script.to_json()
-            if self.get_backup_configuration_script
-            else None,
+            "GetBackupConfigurationScript": (
+                self.get_backup_configuration_script.to_json() if self.get_backup_configuration_script else None
+            ),
             "StorageContainer": self.storage_container,
             "RemoteFolderName": self.remote_folder_name,
             "AccountName": self.account_name,
@@ -275,9 +277,11 @@ class FtpSettings(BackupSettings):
     def from_json(cls, json_dict: Dict[str, Any]) -> FtpSettings:
         return cls(
             json_dict["Disabled"],
-            GetBackupConfigurationScript.from_json(json_dict["GetBackupConfigurationScript"])
-            if json_dict["GetBackupConfigurationScript"]
-            else None,
+            (
+                GetBackupConfigurationScript.from_json(json_dict["GetBackupConfigurationScript"])
+                if json_dict["GetBackupConfigurationScript"]
+                else None
+            ),
             json_dict["Url"],
             json_dict["Port"] if "Port" in json_dict else None,
             json_dict["UserName"],
@@ -289,9 +293,9 @@ class FtpSettings(BackupSettings):
     def to_json(self) -> Dict[str, Any]:
         return {
             "Disabled": self.disabled,
-            "GetBackupConfigurationScript": self.get_backup_configuration_script.to_json()
-            if self.get_backup_configuration_script
-            else None,
+            "GetBackupConfigurationScript": (
+                self.get_backup_configuration_script.to_json() if self.get_backup_configuration_script else None
+            ),
             "Url": self.url,
             "Port": self.port,
             "UserName": self.user_name,
@@ -419,26 +423,30 @@ class BackupConfiguration:
         return cls(
             BackupType(json_dict["BackupType"]),
             SnapshotSettings.from_json(json_dict["SnapshotSettings"]) if json_dict["SnapshotSettings"] else None,
-            BackupEncryptionSettings.from_json(json_dict["BackupEncryptionSettings"])
-            if json_dict["BackupEncryptionSettings"]
-            else None,
+            (
+                BackupEncryptionSettings.from_json(json_dict["BackupEncryptionSettings"])
+                if json_dict["BackupEncryptionSettings"]
+                else None
+            ),
             LocalSettings.from_json(json_dict["LocalSettings"]) if json_dict["LocalSettings"] else None,
             S3Settings.from_json(json_dict["S3Settings"]) if json_dict["S3Settings"] else None,
             GlacierSettings.from_json(json_dict["GlacierSettings"]) if json_dict["GlacierSettings"] else None,
             AzureSettings.from_json(json_dict["AzureSettings"]) if json_dict["AzureSettings"] else None,
             FtpSettings.from_json(json_dict["FtpSettings"]) if json_dict["FtpSettings"] else None,
-            GoogleCloudSettings.from_json(json_dict["GoogleCloudSettings"])
-            if json_dict["GoogleCloudSettings"]
-            else None,
+            (
+                GoogleCloudSettings.from_json(json_dict["GoogleCloudSettings"])
+                if json_dict["GoogleCloudSettings"]
+                else None
+            ),
         )
 
     def to_json(self) -> Dict[str, Any]:
         return {
             "BackupType": self.backup_type.value if self.backup_type else None,
             "SnapshotSettings": self.snapshot_settings.to_json() if self.snapshot_settings else None,
-            "BackupEncryptionSettings": self.backup_encryption_settings.to_json()
-            if self.backup_encryption_settings
-            else None,
+            "BackupEncryptionSettings": (
+                self.backup_encryption_settings.to_json() if self.backup_encryption_settings else None
+            ),
             "LocalSettings": self.local_settings.to_json() if self.local_settings else None,
             "S3Settings": self.s3_settings.to_json() if self.s3_settings else None,
             "GlacierSettings": self.glacier_settings.to_json() if self.glacier_settings else None,

--- a/ravendb/documents/operations/configuration/definitions.py
+++ b/ravendb/documents/operations/configuration/definitions.py
@@ -44,12 +44,12 @@ class ClientConfiguration:
             "Etag": self.etag,
             "Disabled": self.disabled,
             "MaxNumberOfRequestsPerSession": self.max_number_of_requests_per_session,
-            "ReadBalanceBehavior": self.read_balance_behavior.value
-            if self.read_balance_behavior
-            else ReadBalanceBehavior.NONE,
-            "LoadBalanceBehavior": self.load_balance_behavior.value
-            if self.load_balance_behavior
-            else LoadBalanceBehavior.NONE,
+            "ReadBalanceBehavior": (
+                self.read_balance_behavior.value if self.read_balance_behavior else ReadBalanceBehavior.NONE
+            ),
+            "LoadBalanceBehavior": (
+                self.load_balance_behavior.value if self.load_balance_behavior else LoadBalanceBehavior.NONE
+            ),
             "LoadBalancerContextSeed": self.load_balancer_context_seed,
         }
 

--- a/ravendb/documents/operations/revisions.py
+++ b/ravendb/documents/operations/revisions.py
@@ -71,9 +71,9 @@ class RevisionsConfiguration:
     def to_json(self) -> Dict[str, Any]:
         return {
             "Default": self.default_config.to_json() if self.default_config else None,
-            "Collections": {key: value.to_json() for key, value in self.collections.items()}
-            if self.collections
-            else None,
+            "Collections": (
+                {key: value.to_json() for key, value in self.collections.items()} if self.collections else None
+            ),
         }
 
     @classmethod

--- a/ravendb/documents/session/document_session_operations/in_memory_document_session_operations.py
+++ b/ravendb/documents/session/document_session_operations/in_memory_document_session_operations.py
@@ -148,9 +148,9 @@ class DocumentsByEntityHolder(object):
         self.__documents_by_entity_hashable: Dict[object, DocumentInfo] = dict()
         self.__documents_by_entity_unhashable: RefEqEntityHolder[RefEq, DocumentInfo] = RefEqEntityHolder()
         self.__on_before_store_documents_by_entity_hashable: Dict[object, DocumentInfo] = dict()
-        self.__on_before_store_documents_by_entity_unhashable: RefEqEntityHolder[
-            RefEq, DocumentInfo
-        ] = RefEqEntityHolder()
+        self.__on_before_store_documents_by_entity_unhashable: RefEqEntityHolder[RefEq, DocumentInfo] = (
+            RefEqEntityHolder()
+        )
         self.__prepare_entities_puts: bool = False
 
     def __repr__(self):
@@ -458,9 +458,9 @@ class InMemoryDocumentSessionOperations:
         self._documents_by_id = DocumentsByIdHolder()
         self._included_documents_by_id = CaseInsensitiveDict()
         self.include_revisions_by_change_vector = CaseInsensitiveDict()
-        self.include_revisions_by_date_time_before: Optional[
-            Dict[str, Dict[datetime.datetime, DocumentInfo]]
-        ] = CaseInsensitiveDict()
+        self.include_revisions_by_date_time_before: Optional[Dict[str, Dict[datetime.datetime, DocumentInfo]]] = (
+            CaseInsensitiveDict()
+        )
         self._documents_by_entity: DocumentsByEntityHolder = DocumentsByEntityHolder()
 
         self._counters_by_doc_id: Dict[str, List[Dict[str, int]]] = CaseInsensitiveDict()

--- a/ravendb/documents/subscriptions/worker.py
+++ b/ravendb/documents/subscriptions/worker.py
@@ -124,9 +124,11 @@ class SubscriptionConnectionServerMessage:
     def from_json(cls, json_dict: Dict) -> SubscriptionConnectionServerMessage:
         return cls(
             SubscriptionConnectionServerMessage.MessageType(json_dict["Type"]),
-            SubscriptionConnectionServerMessage.ConnectionStatus(json_dict["Status"])
-            if "Status" in json_dict
-            else None,
+            (
+                SubscriptionConnectionServerMessage.ConnectionStatus(json_dict["Status"])
+                if "Status" in json_dict
+                else None
+            ),
             json_dict["Data"] if "Data" in json_dict else None,
             json_dict["Includes"] if "Includes" in json_dict else None,
             json_dict["CounterIncludes"] if "CounterIncludes" in json_dict else None,

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -93,12 +93,12 @@ class RequestExecutor:
 
         self.__http_session: Union[None, requests.Session] = None
 
-        self.first_broadcast_attempt_timeout: Union[
-            None, datetime.timedelta
-        ] = conventions.first_broadcast_attempt_timeout
-        self.second_broadcast_attempt_timeout: Union[
-            None, datetime.timedelta
-        ] = conventions.second_broadcast_attempt_timeout
+        self.first_broadcast_attempt_timeout: Union[None, datetime.timedelta] = (
+            conventions.first_broadcast_attempt_timeout
+        )
+        self.second_broadcast_attempt_timeout: Union[None, datetime.timedelta] = (
+            conventions.second_broadcast_attempt_timeout
+        )
 
         self._first_topology_update_task: Union[None, Future] = None
         self._last_known_urls: Union[None, List[str]] = None
@@ -428,9 +428,11 @@ class RequestExecutor:
 
             topology = Topology(
                 self._topology_etag,
-                self.topology_nodes
-                if self.topology_nodes
-                else list(map(lambda url_val: ServerNode(url_val, self._database_name, "!"), initial_urls)),
+                (
+                    self.topology_nodes
+                    if self.topology_nodes
+                    else list(map(lambda url_val: ServerNode(url_val, self._database_name, "!"), initial_urls))
+                ),
             )
 
             self._node_selector = NodeSelector(topology, self._thread_pool_executor)

--- a/ravendb/serverwide/database_record.py
+++ b/ravendb/serverwide/database_record.py
@@ -97,9 +97,11 @@ class DatabaseRecord:
             "Analyzers": self.analyzers,
             "Indexes": self.indexes,
             "IndexesHistory": self.indexes_history_story,
-            "AutoIndexes": {key: AutoIndexDefinition.to_json(auto_index) for key, auto_index in self.auto_indexes}
-            if self.auto_indexes
-            else None,
+            "AutoIndexes": (
+                {key: AutoIndexDefinition.to_json(auto_index) for key, auto_index in self.auto_indexes}
+                if self.auto_indexes
+                else None
+            ),
             "Settings": self.settings,
             "Revisions": self.revisions,
             "TimeSeries": self.time_series,

--- a/ravendb/tests/jvm_migrated_tests/client_tests/subscriptions_tests/test_basic_subscription.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/subscriptions_tests/test_basic_subscription.py
@@ -528,7 +528,9 @@ class TestBasicSubscription(TestBase):
             user = session.load("users/1", User)
             self.assertEqual(user.name, "user_\uD83D\uDE21\uD83D\uDE21\uD83E\uDD2C\uD83D\uDE00😡😡🤬😀")
 
-        creation_options = SubscriptionCreationOptions(name="user_\uD83D\uDE21\uD83D\uDE21\uD83E\uDD2C\uD83D\uDE00😡😡🤬😀")
+        creation_options = SubscriptionCreationOptions(
+            name="user_\uD83D\uDE21\uD83D\uDE21\uD83E\uDD2C\uD83D\uDE00😡😡🤬😀"
+        )
         key = self.store.subscriptions.create_for_options_autocomplete_query(User, creation_options)
         with self.store.subscriptions.get_subscription_worker(SubscriptionWorkerOptions(key), User) as subscription:
             keys = queue.Queue()

--- a/ravendb/tests/jvm_migrated_tests/client_tests/test_first_class_patch.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/test_first_class_patch.py
@@ -60,13 +60,17 @@ class User:
     @classmethod
     def from_json(cls, json_dict: Dict) -> User:
         return cls(
-            [Stuff.from_json(jdict) if jdict is not None else None for jdict in json_dict["stuff"]]
-            if json_dict["stuff"] is not None
-            else None,
+            (
+                [Stuff.from_json(jdict) if jdict is not None else None for jdict in json_dict["stuff"]]
+                if json_dict["stuff"] is not None
+                else None
+            ),
             Utils.string_to_datetime(json_dict["last_login"]),
-            [int(number) if number is not None else None for number in json_dict["numbers"]]
-            if json_dict["numbers"] is not None
-            else None,
+            (
+                [int(number) if number is not None else None for number in json_dict["numbers"]]
+                if json_dict["numbers"] is not None
+                else None
+            ),
         )
 
 

--- a/ravendb/tests/jvm_migrated_tests/client_tests/time_series_tests/test_time_series_raw_query.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/time_series_tests/test_time_series_raw_query.py
@@ -96,9 +96,11 @@ class RawQueryResult:
     def from_json(cls, json_dict: Dict[str, Any]) -> RawQueryResult:
         return cls(
             TimeSeriesAggregationResult.from_json(json_dict["heart_rate"]) if "heart_rate" in json_dict else None,
-            TimeSeriesAggregationResult.from_json(json_dict["blood_pressure"])
-            if "blood_pressure" in json_dict
-            else None,
+            (
+                TimeSeriesAggregationResult.from_json(json_dict["blood_pressure"])
+                if "blood_pressure" in json_dict
+                else None
+            ),
             json_dict["name"] if "name" in json_dict else None,
         )
 

--- a/ravendb/tools/utils.py
+++ b/ravendb/tools/utils.py
@@ -602,9 +602,9 @@ class Utils(object):
                 converted_document = {}
                 for key in document:
                     converted_key = convert_to_snake_case.get(key, key)
-                    converted_document[
-                        converted_key if key == "Id" else Utils.convert_to_snake_case(converted_key)
-                    ] = document[key]
+                    converted_document[converted_key if key == "Id" else Utils.convert_to_snake_case(converted_key)] = (
+                        document[key]
+                    )
                 document = converted_document
             except:
                 pass
@@ -656,9 +656,7 @@ class Utils(object):
         return (
             datetime_obj.strftime(f"%Y-%m-%dT%H:%M:%S.%f{add_suffix}")
             if datetime_obj
-            else None
-            if return_none_if_none
-            else ""
+            else None if return_none_if_none else ""
         )
 
     @staticmethod


### PR DESCRIPTION
Ran 3.8 black which differs from 3.7.
Black on Python 3.7 is outdated due to 3.7 EOL.
Skipping code format check on 3.7, ignored formatter commit from blame

https://issues.hibernatingrhinos.com/issue/RDBC-800/Investigate-failing-tests-on-python-3.8-due-to-invalid-code-format