### PR TITLE
RDBC-835 new_change should return DocumentsChanges, not dict

### DIFF
--- a/ravendb/documents/session/misc.py
+++ b/ravendb/documents/session/misc.py
@@ -124,14 +124,14 @@ class DocumentQueryCustomization:
 
 class DocumentsChanges:
     class ChangeType(Enum):
-        DOCUMENT_DELETED = "document_deleted"
-        DOCUMENT_ADDED = "document_added"
-        FIELD_CHANGED = "field_changed"
-        NEW_FIELD = "new_field"
-        REMOVED_FIELD = "removed_field"
-        ARRAY_VALUE_CHANGED = "array_value_changed"
-        ARRAY_VALUE_ADDED = "array_value_added"
-        ARRAY_VALUE_REMOVED = "array_value_removed"
+        DOCUMENT_DELETED = "DocumentDeleted"
+        DOCUMENT_ADDED = "DocumentAdded"
+        FIELD_CHANGED = "FieldChanged"
+        NEW_FIELD = "NewField"
+        REMOVED_FIELD = "RemovedField"
+        ARRAY_VALUE_CHANGED = "ArrayValueChanged"
+        ARRAY_VALUE_ADDED = "ArrayValueAdded"
+        ARRAY_VALUE_REMOVED = "ArrayValueRemoved"
 
         def __str__(self):
             return self.value

--- a/ravendb/json/json_operation.py
+++ b/ravendb/json/json_operation.py
@@ -24,13 +24,7 @@ class JsonOperation:
 
     @staticmethod
     def new_change(field_path, name, new_value, old_value, doc_changes, change_type):
-        changes = {
-            "old_value": old_value,
-            "new_value": new_value,
-            "change": change_type,
-            "field_name": name,
-            "field_path": field_path,
-        }
+        changes = DocumentsChanges(old_value, new_value, change_type, name, field_path)
         doc_changes.append(changes)
 
     @staticmethod

--- a/ravendb/tests/jvm_migrated_tests/crud_tests/test_RavenDB_15531.py
+++ b/ravendb/tests/jvm_migrated_tests/crud_tests/test_RavenDB_15531.py
@@ -1,3 +1,4 @@
+from ravendb import DocumentsChanges
 from ravendb.tests.test_base import TestBase
 
 
@@ -23,10 +24,10 @@ class TestRavenDB15531(TestBase):
             self.assertIsNotNone(changes)
             self.assertEqual(1, len(changes))
 
-            self.assertEqual(str(changes[0]["change"]), "field_changed")
-            self.assertEqual(changes[0]["field_name"], "name")
-            self.assertEqual(changes[0]["old_value"], "State1")
-            self.assertEqual(changes[0]["new_value"], "State2")
+            self.assertEqual(changes[0].change, DocumentsChanges.ChangeType.FIELD_CHANGED)
+            self.assertEqual(changes[0].field_name, "name")
+            self.assertEqual(changes[0].field_old_value, "State1")
+            self.assertEqual(changes[0].field_new_value, "State2")
             session.save_changes()
 
             doc.name = "State3"
@@ -35,10 +36,10 @@ class TestRavenDB15531(TestBase):
             self.assertIsNotNone(changes)
             self.assertEqual(1, len(changes))
 
-            self.assertEqual(str(changes[0]["change"]), "field_changed")
-            self.assertEqual(changes[0]["field_name"], "name")
-            self.assertEqual(changes[0]["old_value"], "State2")
-            self.assertEqual(changes[0]["new_value"], "State3")
+            self.assertEqual(changes[0].change, DocumentsChanges.ChangeType.FIELD_CHANGED)
+            self.assertEqual(changes[0].field_name, "name")
+            self.assertEqual(changes[0].field_old_value, "State2")
+            self.assertEqual(changes[0].field_new_value, "State3")
 
             doc = session.advanced.refresh(doc)
 
@@ -48,8 +49,8 @@ class TestRavenDB15531(TestBase):
             self.assertIsNotNone(changes)
             self.assertEqual(1, len(changes))
 
-            self.assertEqual(str(changes[0]["change"]), "field_changed")
-            self.assertEqual(changes[0]["field_name"], "name")
-            self.assertEqual(changes[0]["old_value"], "State2")
-            self.assertEqual(changes[0]["new_value"], "State4")
+            self.assertEqual(changes[0].change, DocumentsChanges.ChangeType.FIELD_CHANGED)
+            self.assertEqual(changes[0].field_name, "name")
+            self.assertEqual(changes[0].field_old_value, "State2")
+            self.assertEqual(changes[0].field_new_value, "State4")
             session.save_changes()

--- a/ravendb/tests/jvm_migrated_tests/crud_tests/test_crud.py
+++ b/ravendb/tests/jvm_migrated_tests/crud_tests/test_crud.py
@@ -1,3 +1,4 @@
+from ravendb import DocumentsChanges
 from ravendb.tests.test_base import TestBase, User
 
 
@@ -73,27 +74,27 @@ class TestCrud(TestBase):
             self.assertEqual(4, len(changes["family/1"]))
 
             #  just dealing with async results to make proper assertion
-            changes = sorted(changes["family/1"], key=lambda change: (change["field_name"], change["old_value"]))
+            changes = sorted(changes["family/1"], key=lambda change: (change.field_name, change.field_old_value))
 
-            self.assertEqual("age", changes[0]["field_name"])
-            self.assertEqual("field_changed", str(changes[0]["change"]))
-            self.assertEqual(4, changes[0]["old_value"])
-            self.assertEqual(8, changes[0]["new_value"])
+            self.assertEqual("age", changes[0].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[0].change)
+            self.assertEqual(4, changes[0].field_old_value)
+            self.assertEqual(8, changes[0].field_new_value)
 
-            self.assertEqual("age", changes[1]["field_name"])
-            self.assertEqual("field_changed", str(changes[1]["change"]))
-            self.assertEqual(8, changes[1]["old_value"])
-            self.assertEqual(4, changes[1]["new_value"])
+            self.assertEqual("age", changes[1].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[1].change)
+            self.assertEqual(8, changes[1].field_old_value)
+            self.assertEqual(4, changes[1].field_new_value)
 
-            self.assertEqual("name", changes[2]["field_name"])
-            self.assertEqual("field_changed", str(changes[2]["change"]))
-            self.assertEqual("Hibernating Rhinos", changes[2]["old_value"])
-            self.assertEqual("RavenDB", changes[2]["new_value"])
+            self.assertEqual("name", changes[2].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[2].change)
+            self.assertEqual("Hibernating Rhinos", changes[2].field_old_value)
+            self.assertEqual("RavenDB", changes[2].field_new_value)
 
-            self.assertEqual("name", changes[3]["field_name"])
-            self.assertEqual("field_changed", str(changes[3]["change"]))
-            self.assertEqual("RavenDB", changes[3]["old_value"])
-            self.assertEqual("Hibernating Rhinos", changes[3]["new_value"])
+            self.assertEqual("name", changes[3].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[3].change)
+            self.assertEqual("RavenDB", changes[3].field_old_value)
+            self.assertEqual("Hibernating Rhinos", changes[3].field_new_value)
 
             member1 = Member("Toli", 5)
             member2 = Member("Boki", 15)
@@ -103,27 +104,27 @@ class TestCrud(TestBase):
             self.assertEqual(1, len(changes))
             self.assertEqual(4, len(changes["family/1"]))
 
-            changes = sorted(changes["family/1"], key=lambda change: (change["field_name"], change["old_value"]))
+            changes = sorted(changes["family/1"], key=lambda change: (change.field_name, change.field_old_value))
 
-            self.assertEqual("age", changes[0]["field_name"])
-            self.assertEqual("field_changed", str(changes[0]["change"]))
-            self.assertEqual(4, changes[0]["old_value"])
-            self.assertEqual(15, changes[0]["new_value"])
+            self.assertEqual("age", changes[0].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[0].change)
+            self.assertEqual(4, changes[0].field_old_value)
+            self.assertEqual(15, changes[0].field_new_value)
 
-            self.assertEqual("age", changes[1]["field_name"])
-            self.assertEqual("field_changed", str(changes[1]["change"]))
-            self.assertEqual(8, changes[1]["old_value"])
-            self.assertEqual(5, changes[1]["new_value"])
+            self.assertEqual("age", changes[1].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[1].change)
+            self.assertEqual(8, changes[1].field_old_value)
+            self.assertEqual(5, changes[1].field_new_value)
 
-            self.assertEqual("name", changes[2]["field_name"])
-            self.assertEqual("field_changed", str(changes[2]["change"]))
-            self.assertEqual("Hibernating Rhinos", changes[2]["old_value"])
-            self.assertEqual("Toli", changes[2]["new_value"])
+            self.assertEqual("name", changes[2].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[2].change)
+            self.assertEqual("Hibernating Rhinos", changes[2].field_old_value)
+            self.assertEqual("Toli", changes[2].field_new_value)
 
-            self.assertEqual("name", changes[3]["field_name"])
-            self.assertEqual("field_changed", str(changes[3]["change"]))
-            self.assertEqual("RavenDB", changes[3]["old_value"])
-            self.assertEqual("Boki", changes[3]["new_value"])
+            self.assertEqual("name", changes[3].field_name)
+            self.assertEqual(DocumentsChanges.ChangeType.FIELD_CHANGED, changes[3].change)
+            self.assertEqual("RavenDB", changes[3].field_old_value)
+            self.assertEqual("Boki", changes[3].field_new_value)
 
     def test_crud_operations_with_array_in_object(self):
         with self.store.open_session() as session:
@@ -221,19 +222,19 @@ class TestCrud(TestBase):
             change = changes["arr/1"]
             self.assertEqual(4, len(change))
 
-            change = sorted(change, key=lambda ch: (ch["old_value"], ch["new_value"]))
+            change = sorted(change, key=lambda ch: (ch.field_old_value, ch.field_new_value))
 
-            self.assertEqual("a", change[0]["old_value"])
-            self.assertEqual("d", change[0]["new_value"])
+            self.assertEqual("a", change[0].field_old_value)
+            self.assertEqual("d", change[0].field_new_value)
 
-            self.assertEqual("b", change[1]["old_value"])
-            self.assertEqual("c", change[1]["new_value"])
+            self.assertEqual("b", change[1].field_old_value)
+            self.assertEqual("c", change[1].field_new_value)
 
-            self.assertEqual("c", change[2]["old_value"])
-            self.assertEqual("a", change[2]["new_value"])
+            self.assertEqual("c", change[2].field_old_value)
+            self.assertEqual("a", change[2].field_new_value)
 
-            self.assertEqual("d", change[3]["old_value"])
-            self.assertEqual("b", change[3]["new_value"])
+            self.assertEqual("d", change[3].field_old_value)
+            self.assertEqual("b", change[3].field_new_value)
 
             session.save_changes()
 
@@ -248,13 +249,13 @@ class TestCrud(TestBase):
 
             change = changes["arr/1"]
             self.assertEqual(2, len(change))
-            change = sorted(change, key=lambda ch: (ch["old_value"], ch["new_value"]))
+            change = sorted(change, key=lambda ch: (ch.field_old_value, ch.field_new_value))
 
-            self.assertEqual("c", change[0]["old_value"])
-            self.assertEqual("w", change[0]["new_value"])
+            self.assertEqual("c", change[0].field_old_value)
+            self.assertEqual("w", change[0].field_new_value)
 
-            self.assertEqual("d", change[1]["old_value"])
-            self.assertEqual("q", change[1]["new_value"])
+            self.assertEqual("d", change[1].field_old_value)
+            self.assertEqual("q", change[1].field_new_value)
 
             session.save_changes()
 

--- a/ravendb/tests/jvm_migrated_tests/what_changed_tests/test_RavenDB_11649.py
+++ b/ravendb/tests/jvm_migrated_tests/what_changed_tests/test_RavenDB_11649.py
@@ -33,7 +33,7 @@ class TestRavenDB10641(TestBase):
             session.save_changes()
             doc.inner_classes[0].a = "newInnerValue"
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changed_paths, "inner_classes[0]")
 
     def test_what_changed_when_property_of_inner_property_changed_to_null_should_return_property_name_plus_path(self):
@@ -46,7 +46,7 @@ class TestRavenDB10641(TestBase):
 
             doc.inner_class.a = None
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changed_paths, "inner_class")
 
     def test_what_changed_when_inner_property_changed_should_return_the_property_name_plus_path(self):
@@ -59,7 +59,7 @@ class TestRavenDB10641(TestBase):
 
             doc.inner_class.a = "newInnerValue"
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changed_paths, "inner_class")
 
     def test_what_changed_when_outer_property_changed_field_path_should_be_empty(self):
@@ -72,7 +72,7 @@ class TestRavenDB10641(TestBase):
 
             doc.a = "newOuterValue"
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changed_paths, "")
 
     def test_what_changed_when_all_named_a_properties_changed_should_return_different_paths(self):
@@ -94,7 +94,7 @@ class TestRavenDB10641(TestBase):
             doc.inner_classes[0].a = "newValue"
             doc.inner_class_matrix[0][0].a = "newValue"
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(
                 changed_paths, "", "inner_class", "inner_classes[0]", "inner_class_matrix[0][0]"
             )
@@ -110,7 +110,7 @@ class TestRavenDB10641(TestBase):
             doc.inner_class.a = "newInnerValue"
 
             changes = session.advanced.what_changed()
-            changed_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changed_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changed_paths, "inner_class")
 
     def test_what_changed_when_in_matrix_changed_should_return_with_relevant_path(self):
@@ -124,7 +124,7 @@ class TestRavenDB10641(TestBase):
             doc.inner_class_matrix[0][0].a = "newValue"
 
             changes = session.advanced.what_changed()
-            changes_paths = list(map(lambda change: change["field_path"], changes["docs/1"]))
+            changes_paths = list(map(lambda change: change.field_path, changes["docs/1"]))
             self.assertSequenceContainsElements(changes_paths, "inner_class_matrix[0][0]")
 
     def test_what_changed_when_array_property_in_array_changed_from_null_should_return_relevant_path(self):
@@ -137,5 +137,5 @@ class TestRavenDB10641(TestBase):
             doc.inner_class_matrix[0] = [InnerClass(None)]
 
             changes = session.advanced.what_changed()
-            changes_paths = list(map(lambda change: change["field_path"], changes[key]))
+            changes_paths = list(map(lambda change: change.field_path, changes[key]))
             self.assertSequenceContainsElements(changes_paths, "inner_class_matrix[0]")


### PR DESCRIPTION
breaking change
https://issues.hibernatingrhinos.com/issue/RDBC-835/newchange-should-return-DocumentsChanges-not-dict