### PR TITLE
RDBC-849 Set QueryOperationOptions.allow_stale to False by default

### DIFF
--- a/ravendb/documents/operations/misc.py
+++ b/ravendb/documents/operations/misc.py
@@ -46,7 +46,7 @@ class GetOperationStateOperation(MaintenanceOperation):
 class QueryOperationOptions(object):
     def __init__(
         self,
-        allow_stale: bool = True,
+        allow_stale: bool = False,
         stale_timeout: datetime.timedelta = None,
         max_ops_per_sec: int = None,
         retrieve_details: bool = False,


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-849/Set-QueryOperationOptions.allowstale-to-False-by-default
breaking change