### PR TITLE
Release Connection String operations - 7.1.2post2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.1.2.post1",
+    version="7.1.2.post2",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
This PR bumps version to 7.1.2post2 - this update includes Connection String Operations - https://github.com/ravendb/ravendb-python-client/pull/247