### PR TITLE
RDBC-949: Refactors is_read_request to a method

### DIFF
--- a/ravendb/documents/commands/batches.py
+++ b/ravendb/documents/commands/batches.py
@@ -130,8 +130,7 @@ class SingleNodeBatchCommand(RavenCommand):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    @property
-    def is_read_request(self):
+    def is_read_request(self) -> bool:
         return False
 
     def create_request(self, node: ServerNode) -> requests.Request:

--- a/ravendb/documents/commands/crud.py
+++ b/ravendb/documents/commands/crud.py
@@ -324,7 +324,6 @@ class GetDocumentsCommand(RavenCommand[GetDocumentsResult]):
     def set_response(self, response: str, from_cache: bool) -> None:
         self.result = GetDocumentsResult.from_json(json.loads(response)) if response is not None else None
 
-    @property
     def is_read_request(self) -> bool:
         return True
 

--- a/ravendb/documents/commands/multi_get.py
+++ b/ravendb/documents/commands/multi_get.py
@@ -248,7 +248,6 @@ class MultiGetCommand(RavenCommand):
 
         return get_response
 
-    @property
     def is_read_request(self) -> bool:
         return False
 

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -691,7 +691,7 @@ class RequestExecutor:
             if session_info is not None and session_info.can_use_load_balance_behavior:
                 return self._node_selector.get_node_by_session_id(session_info.session_id)
 
-        if not cmd.is_read_request:
+        if not cmd.is_read_request():
             return self._node_selector.get_preferred_node()
 
         if self.conventions.read_balance_behavior == ReadBalanceBehavior.NONE:
@@ -783,7 +783,7 @@ class RequestExecutor:
         if (
             use_cache
             and command.can_cache
-            and command.is_read_request
+            and command.is_read_request()
             and command.response_type == RavenCommandResponseType.OBJECT
         ):
             return self._cache.get(url)

--- a/ravendb/tests/raven_commands_tests/test_platform_contracts.py
+++ b/ravendb/tests/raven_commands_tests/test_platform_contracts.py
@@ -1,0 +1,52 @@
+import unittest
+import importlib
+import inspect
+import pkgutil
+import ravendb
+
+from ravendb.tests.test_base import TestBase
+
+
+class TestPlatformContracts(TestBase):
+    def setUp(self):
+        super(TestPlatformContracts, self).setUp()
+
+    def tearDown(self):
+        super(TestPlatformContracts, self).tearDown()
+        TestBase.delete_all_topology_files()
+
+    def test_all_commands_expose_callable_is_read_request(self):
+        from ravendb.http.raven_command import RavenCommand
+
+        offenders = []
+        for mod in self._import_all_ravendb_modules():
+            for cls in self._iter_subclasses_in_module(mod, RavenCommand):
+                attr = getattr(cls, "is_read_request", None)
+                if isinstance(attr, property):
+                    offenders.append(f"{cls.__module__}.{cls.__qualname__}")
+
+        if offenders:
+            self.fail("is_read_request must be a method on: " + ", ".join(offenders))
+
+    # private helpers
+    def _import_all_ravendb_modules(self):
+        for _, modname, _ in pkgutil.walk_packages(ravendb.__path__, ravendb.__name__ + "."):
+            if modname.startswith("ravendb.tests."):
+                continue
+            try:
+                yield importlib.import_module(modname)
+            except Exception:
+                continue
+
+    def _iter_subclasses_in_module(self, mod, base_cls):
+        for _, obj in inspect.getmembers(mod):
+            if inspect.isclass(obj) and issubclass(obj, base_cls) and obj is not base_cls:
+                yield obj
+            if inspect.isclass(obj):
+                for _, inner in inspect.getmembers(obj, inspect.isclass):
+                    if issubclass(inner, base_cls) and inner is not base_cls:
+                        yield inner
+
+
+if __name__ == "__main__":
+    unittest.main


### PR DESCRIPTION
Ensures `is_read_request` is consistently implemented as a method rather than a property across all commands.

This change fixes potential issues where the intended behavior of checking if a command is a read request might not be correctly executed due to inconsistent implementation.

Adds a test to verify the consistent implementation of `is_read_request`.