### PR TITLE
RDBC-940 v7.0 Zstd-compression data prevents simple store.

### DIFF
--- a/ravendb/http/raven_command.py
+++ b/ravendb/http/raven_command.py
@@ -97,14 +97,23 @@ class RavenCommand(Generic[_T_Result]):
         )
 
     def send(self, session: requests.Session, request: requests.Request) -> requests.Response:
-        return session.request(
-            request.method,
-            url=request.url,
-            data=request.data,
-            files=request.files,
-            cert=session.cert,
-            headers=request.headers,
-        )
+        prepared_request = session.prepare_request(request)
+        self._remove_zstd_encoding(prepared_request)
+        return session.send(prepared_request, cert=session.cert)
+
+    # https://issues.hibernatingrhinos.com/issue/RDBC-940
+    # If user has installed module 'zstd' or 'zstandard',
+    # 'requests' module will automatically add 'zstd' to 'Accept-Encoding' header.
+    # This causes exceptions. Excluding 'zstd' from the header in this workaround,
+    # while we keep investigating cause of the issue.
+    @staticmethod
+    def _remove_zstd_encoding(request: requests.PreparedRequest) -> None:
+        accept_encoding = request.headers.get("Accept-Encoding")
+
+        if "zstd" in accept_encoding:
+            encodings = [encoding.strip() for encoding in accept_encoding.split(",") if encoding.strip().lower() != "zstd"]
+            new_header_value = ", ".join(encodings)
+            request.headers["Accept-Encoding"] = new_header_value
 
     def set_response_raw(self, response: requests.Response, stream: bytes) -> None:
         raise RuntimeError(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.0.2",
+    version="7.0.2.post1",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-940

If user has installed module 'zstd' or 'zstandard', 'requests' module will automatically add 'zstd' to 'Accept-Encoding' header.
This causes exceptions. Excluding 'zstd' from the header in this workaround, while we keep investigating cause of the issue.