### PR TITLE
RDBC-1031 Default CounterOperation.INCREMENT delta to 1

### DIFF
--- a/ravendb/documents/operations/counters.py
+++ b/ravendb/documents/operations/counters.py
@@ -35,7 +35,7 @@ class CounterOperation:
         if not counter_operation_type:
             raise ValueError(f"Missing counter_operation_type property in counter {counter_name}")
         if delta is None and counter_operation_type == CounterOperationType.INCREMENT:
-            raise ValueError(f"Missing delta property in counter {counter_name} of type {counter_operation_type}")
+            delta = 1
         self.counter_name = counter_name
         self.delta = delta
         self.counter_operation_type = counter_operation_type

--- a/ravendb/tests/counters_tests/test_counter_increment_default_delta.py
+++ b/ravendb/tests/counters_tests/test_counter_increment_default_delta.py
@@ -1,0 +1,58 @@
+"""
+Counter increment: omitting delta when incrementing defaults to delta=1.
+
+C# reference: SlowTests.Issues/Issues/RavenDB_22150.cs
+  IncrementByDefaultValue
+"""
+
+from ravendb.documents.operations.counters import (
+    CounterBatch,
+    CounterBatchOperation,
+    CounterOperation,
+    CounterOperationType,
+    DocumentCountersOperation,
+)
+from ravendb.infrastructure.entities import User
+from ravendb.tests.test_base import TestBase
+
+
+class TestRavenDB22150(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_increment_without_delta_defaults_to_one(self):
+        """
+        CounterOperation(INCREMENT) with no delta argument defaults to delta=1
+        on the client, matching the C# client's permissive default.
+
+        C# spec: IncrementByDefaultValue — sends a batch with two operations:
+          one with an explicit delta and one with no delta. The no-delta
+          operation should increment by 1.
+        """
+        with self.store.open_session() as session:
+            session.store(User(name="Danielle"), "users/1")
+            session.save_changes()
+
+        with self.store.open_session() as session:
+            session.counters_for("users/1").increment("likes", 10)
+            session.counters_for("users/1").increment("dislikes", 20)
+            session.save_changes()
+
+        # Single batch: explicit delta=5 for likes, no delta for dislikes (defaults to 1).
+        result = self.store.operations.send(
+            CounterBatchOperation(
+                CounterBatch(
+                    documents=[
+                        DocumentCountersOperation(
+                            document_id="users/1",
+                            operations=[
+                                CounterOperation("likes", CounterOperationType.INCREMENT, delta=5),
+                                CounterOperation("dislikes", CounterOperationType.INCREMENT),
+                            ],
+                        )
+                    ]
+                )
+            )
+        )
+
+        self.assertEqual(21, result.counters[1].total_value)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1031

### Additional description

`CounterOperation.INCREMENT` raised a `ValueError` when `delta` was omitted, but the C# client defaults it to `1` in that case. Fixed by assigning `delta = 1` instead of raising, matching the reference client behaviour.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed