### PR TITLE
RDBC-1021/1024/1025 Fix no-tracking includes guard, session refresh in-place, and lazy load None

### DIFF
--- a/ravendb/documents/session/document_session.py
+++ b/ravendb/documents/session/document_session.py
@@ -316,6 +316,13 @@ class DocumentSession(InMemoryDocumentSessionOperations):
             result = load_operation.get_documents(object_type)
             return result.popitem()[1] if len(result) == 1 else result if result else None
 
+        if self.no_tracking:
+            raise InvalidOperationException(
+                "Cannot register includes when no_tracking is enabled. "
+                "Included documents are not tracked, so subsequent load operations for that data will still trigger additional server requests. "
+                "To avoid confusion, include operations are disallowed when tracking is disabled on the session or query."
+            )
+
         include_builder = IncludeBuilder(self.conventions)
         includes(include_builder)
 

--- a/ravendb/documents/session/document_session_operations/in_memory_document_session_operations.py
+++ b/ravendb/documents/session/document_session_operations/in_memory_document_session_operations.py
@@ -1789,16 +1789,19 @@ class InMemoryDocumentSessionOperations:
         if document_info.entity is not None and not self.no_tracking:
             self.entity_to_json.remove_from_missing(document_info.entity)
 
-        document_info.entity = self.entity_to_json.convert_to_entity(
+        refreshed = self.entity_to_json.convert_to_entity(
             type(entity), document_info.key, document, not self.no_tracking
         )
         document_info.document = document
 
+        # Update the original entity object in-place so the caller's reference
+        # immediately reflects the new server state (C# behaviour).
         try:
-            entity = deepcopy(document_info.entity)
-        except Error as e:
-            raise RuntimeError(f"Unable to refresh entity: {e.args[0]}", e)
+            entity.__dict__.update(refreshed.__dict__)
+        except Exception as e:
+            raise RuntimeError(f"Unable to refresh entity: {e}") from e
 
+        document_info.entity = entity
         document_info_by_id = self._documents_by_id.get(document_info.key)
         if document_info_by_id is not None:
             document_info_by_id.entity = entity

--- a/ravendb/documents/session/operations/lazy.py
+++ b/ravendb/documents/session/operations/lazy.py
@@ -191,6 +191,8 @@ class LazySessionOperations:
     def load(
         self, ids: Union[List[str], str], object_type: Optional[Type[_T]] = None, on_eval: Callable = None
     ) -> Optional[Lazy[Union[Dict[str, object], object]]]:
+        if ids is None:
+            return Lazy(lambda: None)
         if not ids:
             return None
 

--- a/ravendb/documents/session/query.py
+++ b/ravendb/documents/session/query.py
@@ -52,6 +52,7 @@ from ravendb.documents.queries.suggestions import (
     SuggestionBuilder,
 )
 from ravendb.documents.queries.utils import QueryFieldUtil
+from ravendb.exceptions.exceptions import InvalidOperationException
 from ravendb.documents.session.event_args import BeforeQueryEventArgs
 from ravendb.documents.session.loaders.include import IncludeBuilderBase, QueryIncludeBuilder
 from ravendb.documents.session.misc import MethodCall, CmpXchg, OrderingType, DocumentQueryCustomization
@@ -368,6 +369,12 @@ class AbstractDocumentQuery(Generic[_T]):
         return MoreLikeThisScope(token, self.__add_query_parameter, __action)
 
     def _include(self, path_or_include_builder: Union[str, IncludeBuilderBase]) -> None:
+        if self._the_session is not None and self._the_session.no_tracking:
+            raise InvalidOperationException(
+                "Cannot register includes when no_tracking is enabled. "
+                "Included documents are not tracked, so subsequent load operations for that data will still trigger additional server requests. "
+                "To avoid confusion, include operations are disallowed when tracking is disabled on the session or query."
+            )
         if isinstance(path_or_include_builder, str):
             self._document_includes.add(path_or_include_builder)
         elif isinstance(path_or_include_builder, IncludeBuilderBase):

--- a/ravendb/tests/jvm_migrated_tests/issues_tests/test_ravenDB_11217.py
+++ b/ravendb/tests/jvm_migrated_tests/issues_tests/test_ravenDB_11217.py
@@ -37,7 +37,7 @@ class TestRavenDB11217(TestBase):
         with self.store.open_session(session_options=no_tracking_options) as session:
             self.assertEqual(0, session.advanced.number_of_requests)
 
-            product1 = session.load("products/1-A", Product, lambda b: b.include_documents("supplier"))
+            product1 = session.load("products/1-A", Product)
 
             self.assertEqual(1, session.advanced.number_of_requests)
 
@@ -52,7 +52,7 @@ class TestRavenDB11217(TestBase):
             self.assertEqual(2, session.advanced.number_of_requests)
             self.assertFalse(session.advanced.is_loaded(supplier.Id))
 
-            product2 = session.load("products/1-A", Product, lambda b: b.include_documents(("supplier")))
+            product2 = session.load("products/1-A", Product)
             self.assertNotEqual(product2, product1)
 
         with self.store.open_session(session_options=no_tracking_options) as session:
@@ -79,7 +79,7 @@ class TestRavenDB11217(TestBase):
 
         with self.store.open_session(session_options=no_tracking_options) as session:
             self.assertEqual(0, session.advanced.number_of_requests)
-            products = list(session.query(object_type=Product).include("supplier"))
+            products = list(session.query(object_type=Product))
 
             self.assertEqual(1, session.advanced.number_of_requests)
             self.assertEqual(1, len(products))
@@ -95,7 +95,7 @@ class TestRavenDB11217(TestBase):
             self.assertEqual(2, session.advanced.number_of_requests)
             self.assertFalse(session.advanced.is_loaded(supplier.Id))
 
-            products = list(session.query(object_type=Product).include("supplier"))
+            products = list(session.query(object_type=Product))
             self.assertEqual(1, len(products))
 
             product2 = products[0]

--- a/ravendb/tests/session_tests/test_lazy_load_null.py
+++ b/ravendb/tests/session_tests/test_lazy_load_null.py
@@ -1,0 +1,29 @@
+"""
+Lazy load: lazily.load(None) returns a Lazy that resolves to None.
+
+C# reference: SlowTests/Issues/RavenDB_21859.cs
+  Load_And_Lazy_Load_Should_Return_Null_When_Id_Is_Null
+"""
+
+from ravendb.tests.test_base import TestBase
+
+
+class User:
+    def __init__(self, name: str = None):
+        self.name = name
+
+
+class TestRavenDB21859(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_load_null_id_returns_none(self):
+        with self.store.open_session() as session:
+            result = session.load(None, User)
+            self.assertIsNone(result)
+
+    def test_lazily_load_null_id_returns_none(self):
+        with self.store.open_session() as session:
+            lazy = session.advanced.lazily.load(None, User)
+            session.advanced.eagerly.execute_all_pending_lazy_operations()
+            self.assertIsNone(lazy.value)

--- a/ravendb/tests/session_tests/test_no_tracking_includes_guard.py
+++ b/ravendb/tests/session_tests/test_no_tracking_includes_guard.py
@@ -1,0 +1,69 @@
+"""
+No-tracking session: using includes raises when session.no_tracking is True.
+
+C# reference: SlowTests/Issues/RavenDB_21339.cs
+  Using_Includes_In_Non_Tracking_Session_Should_Throw
+"""
+
+from ravendb.documents.session.misc import SessionOptions
+from ravendb.tests.test_base import TestBase
+
+
+class Manager:
+    def __init__(self, name: str = None):
+        self.name = name
+
+
+class Employee:
+    def __init__(self, name: str = None, manager_id: str = None):
+        self.name = name
+        self.manager_id = manager_id
+
+
+class TestRavenDB21339(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def _populate(self):
+        with self.store.open_session() as session:
+            session.store(Manager(name="Boss"), "managers/1")
+            session.store(Employee(name="Alice", manager_id="managers/1"), "employees/1")
+            session.save_changes()
+
+    def test_load_with_includes_in_no_tracking_session_should_throw(self):
+        """
+        session.load() with an include builder in a no_tracking session must
+        raise an exception, not silently ignore the includes."""
+        self._populate()
+
+        with self.store.open_session(session_options=SessionOptions(no_tracking=True)) as session:
+            with self.assertRaises(Exception) as ctx:
+                session.load(
+                    "employees/1",
+                    Employee,
+                    includes=lambda b: b.include_documents("manager_id"),
+                )
+            self.assertIn("Cannot register includes when no_tracking is enabled", str(ctx.exception))
+
+    def test_query_with_include_in_no_tracking_session_should_throw(self):
+        """
+        query.include() in a no_tracking session must raise an exception,
+        not silently add the include to an unused tracking cache."""
+        self._populate()
+
+        with self.store.open_session(session_options=SessionOptions(no_tracking=True)) as session:
+            with self.assertRaises(Exception) as ctx:
+                list(session.query(object_type=Employee).include("manager_id").wait_for_non_stale_results())
+            self.assertIn("Cannot register includes when no_tracking is enabled", str(ctx.exception))
+
+    def test_document_query_with_include_in_no_tracking_session_should_throw(self):
+        """
+        C# spec: session.Advanced.DocumentQuery<Product>().Include(x => x.Supplier).ToList()
+        in a no_tracking session must raise InvalidOperationException.
+        """
+        self._populate()
+
+        with self.store.open_session(session_options=SessionOptions(no_tracking=True)) as session:
+            with self.assertRaises(Exception) as ctx:
+                list(session.advanced.document_query(object_type=Employee).include("manager_id"))
+            self.assertIn("Cannot register includes when no_tracking is enabled", str(ctx.exception))

--- a/ravendb/tests/session_tests/test_session_refresh.py
+++ b/ravendb/tests/session_tests/test_session_refresh.py
@@ -1,0 +1,116 @@
+"""
+Session refresh: advanced.refresh(entity) re-fetches from the server and updates
+the entity object in-place; the refreshed entity stays tracked in the session.
+
+C# reference: FastTests/Client/Store.cs
+  Refresh_stored_document
+"""
+
+from ravendb.tests.test_base import TestBase
+
+
+class User:
+    def __init__(self, name: str = "", age: int = 0):
+        self.name = name
+        self.age = age
+
+
+class TestRavenDBRefreshStoredDocument(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_refresh_updates_entity_in_place(self):
+        """
+        C# spec: after Advanced.Refresh(user), the SAME user object must
+        reflect the server state.  No need to use the return value.
+
+        must use the return value — but that returned entity is not tracked
+        by the session (see test_refresh_returned_entity_is_tracked below)."""
+        with self.store.open_session() as s:
+            s.store(User(name="RVN", age=1), "users/1")
+            s.save_changes()
+
+        with self.store.open_session() as outer:
+            user = outer.load("users/1", User)
+            self.assertEqual(1, user.age, "precondition: age=1 after load")
+
+            # External session updates age to 10 (mirrors C# inner session)
+            with self.store.open_session() as inner:
+                u2 = inner.load("users/1", User)
+                u2.age = 10
+                inner.save_changes()
+
+            # C# spec: after Refresh(user), user.Age == 10
+            outer.advanced.refresh(user)
+
+            self.assertEqual(
+                10,
+                user.age,
+                msg=f"refresh() did not update the entity in-place. user.age is still {user.age} (expected 10).",
+            )
+
+    def test_refresh_returned_entity_is_tracked(self):
+        """
+        refresh() returns the same (mutated-in-place) entity object.
+        That returned value must be session-tracked so that metadata
+        APIs such as get_change_vector_for() work on it."""
+        with self.store.open_session() as s:
+            s.store(User(name="RVN", age=1), "users/1")
+            s.save_changes()
+
+        with self.store.open_session() as outer:
+            user = outer.load("users/1", User)
+
+            with self.store.open_session() as inner:
+                u2 = inner.load("users/1", User)
+                u2.age = 10
+                inner.save_changes()
+
+            returned = outer.advanced.refresh(user)
+
+            # The returned entity should be the refreshed copy.
+            self.assertEqual(
+                10,
+                returned.age,
+                msg="Return value of refresh() should have the updated age.",
+            )
+
+            # The returned entity must be session-tracked so metadata APIs work.
+            cv = outer.advanced.get_change_vector_for(returned)
+            self.assertIsNotNone(cv, "Change vector should be non-None for refreshed entity")
+
+    def test_refresh_updates_change_vector_for_original_entity(self):
+        """
+        C# spec (Refresh_stored_document): after Refresh(user),
+        Advanced.GetChangeVectorFor(user) must return the NEW change vector
+        (not the one recorded at load time), and GetLastModifiedFor(user)
+        must return the new timestamp."""
+        with self.store.open_session() as s:
+            s.store(User(name="RVN", age=1), "users/1")
+            s.save_changes()
+
+        with self.store.open_session() as outer:
+            user = outer.load("users/1", User)
+            cv_before = outer.advanced.get_change_vector_for(user)
+            lm_before = outer.advanced.get_last_modified_for(user)
+
+            with self.store.open_session() as inner:
+                u2 = inner.load("users/1", User)
+                u2.age = 10
+                inner.save_changes()
+
+            outer.advanced.refresh(user)
+
+            cv_after = outer.advanced.get_change_vector_for(user)
+            lm_after = outer.advanced.get_last_modified_for(user)
+
+            self.assertNotEqual(
+                cv_before,
+                cv_after,
+                msg="GetChangeVectorFor(user) must return a new change vector after Refresh()",
+            )
+            self.assertNotEqual(
+                lm_before,
+                lm_after,
+                msg="GetLastModifiedFor(user) must return a new timestamp after Refresh()",
+            )


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1021
https://issues.hibernatingrhinos.com/issue/RDBC-1024
https://issues.hibernatingrhinos.com/issue/RDBC-1025

### Additional description

**RDBC-1021** – `session.query(...).include(...)` and `session.advanced.document_query(...).include(...)` now raise `ValueError` immediately when `session.no_tracking` is `True`, matching C# behaviour. Previously the call succeeded silently and the included documents were never cached.

**RDBC-1024** – `session.advanced.refresh(entity)` was creating a new object and replacing the `DocumentInfo` entry, leaving the caller's original reference stale. Fixed by updating `entity.__dict__` in-place so the caller's reference immediately reflects the refreshed server state.

**RDBC-1025** – `session.advanced.lazily.load(None)` returned `None` instead of `Lazy(None)`. Fixed by returning `Lazy(lambda: None)` for a `None` id, consistent with how the C# client handles it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed