### PR TITLE
RDBC-1029/1030 Fix bulk insert error detection and Enum dict key serialisation

### DIFF
--- a/ravendb/documents/bulk_insert_operation.py
+++ b/ravendb/documents/bulk_insert_operation.py
@@ -356,7 +356,7 @@ class BulkInsertOperation:
 
         result = state_request.result["Result"]
 
-        if result["$type"].starts_with("Raven.Client.Documents.Operations.OperationExceptionResult"):
+        if result["$type"].startswith("Raven.Client.Documents.Operations.OperationExceptionResult"):
             return BulkInsertAbortedException(result["Error"])
 
         return None

--- a/ravendb/tests/documents_tests/test_bulk_insert_error_handling.py
+++ b/ravendb/tests/documents_tests/test_bulk_insert_error_handling.py
@@ -1,0 +1,69 @@
+"""
+BulkInsert: server errors surface as BulkInsertAbortedException with the
+server's error detail; metadata round-trips correctly.
+
+C# reference: FastTests/Client/BulkInsert/BulkInserts.cs
+  CanModifyMetadataWithBulkInsert
+"""
+
+import datetime
+
+from ravendb.json.metadata_as_dictionary import MetadataAsDictionary
+from ravendb.primitives.constants import Documents
+from ravendb.exceptions.documents.bulkinsert import BulkInsertAbortedException
+from ravendb.tests.test_base import TestBase
+
+
+class FooBar:
+    def __init__(self, name: str = ""):
+        self.name = name
+
+
+class TestRavenDBBulkInsert(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_bulk_insert_server_error_raises_aborted_exception(self):
+        """
+        When the server rejects a bulk insert operation,
+        _get_exception_from_operation returns BulkInsertAbortedException
+        carrying the server's error text.
+
+        C# ref: BulkInserts.CanModifyMetadataWithBulkInsert (error path)
+        """
+        # A date-only string triggers a server-side error (@expires requires a full datetime).
+        date_only_expiry = (datetime.date.today() + datetime.timedelta(days=365)).isoformat()
+        meta = MetadataAsDictionary()
+        meta[Documents.Metadata.EXPIRES] = date_only_expiry
+
+        with self.assertRaises(BulkInsertAbortedException) as cm:
+            with self.store.bulk_insert() as bi:
+                bi.store(FooBar(name="Jon Snow"), metadata=meta)
+
+        error_message = str(cm.exception)
+        self.assertNotIn(
+            "Failed to execute bulk insert",
+            error_message,
+            "exception message should contain server error detail, not just the generic fallback",
+        )
+
+    def test_bulk_insert_with_full_datetime_expiry_works(self):
+        """
+        C# spec: BulkInserts.CanModifyMetadataWithBulkInsert — stores a document
+        with @expires set to a full datetime string; the server accepts it and
+        persists the expiry in metadata.
+        """
+        expiry = (datetime.datetime.utcnow() + datetime.timedelta(days=365)).isoformat()
+        meta = MetadataAsDictionary()
+        meta[Documents.Metadata.EXPIRES] = expiry
+
+        with self.store.bulk_insert() as bi:
+            bi.store(FooBar(name="Jon Snow"), metadata=meta)
+
+        with self.store.open_session() as session:
+            entity = session.load("FooBars/1-A", FooBar)
+            self.assertIsNotNone(entity, "Document should have been stored")
+            meta_out = session.advanced.get_metadata_for(entity)
+            stored_expiry = meta_out.get(Documents.Metadata.EXPIRES)
+            self.assertIsNotNone(stored_expiry, "@expires should be persisted in metadata")
+            self.assertEqual(expiry, stored_expiry, "@expires value should round-trip exactly")

--- a/ravendb/tests/documents_tests/test_store_enum_key_dict.py
+++ b/ravendb/tests/documents_tests/test_store_enum_key_dict.py
@@ -1,0 +1,79 @@
+"""
+Serialization: entities whose dict fields use Enum keys store and round-trip
+correctly; Enum keys are serialized as their string values.
+
+C# reference: FastTests/Issues/RavenDB_22084.cs
+  StoreOnDictionaryWithEnumKeyShouldWork
+"""
+
+from enum import Enum
+
+from ravendb.tests.test_base import TestBase
+
+
+class CheckType(Enum):
+    ENGINE = "Engine"
+    GEARS = "Gears"
+
+
+class CheckStatus(Enum):
+    GOOD = "Good"
+    BAD = "Bad"
+
+
+class Machine:
+    def __init__(self, checks=None):
+        self.checks = checks or {}
+
+
+class TestRavenDB22084(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_store_entity_with_enum_keyed_dict(self):
+        """
+        C# spec: StoreOnDictionaryWithEnumKeyShouldWork
+          var m = new Machine { Checks = { [CheckType.Engine] = CheckStatus.Good, ... } }
+          session.Store(m)
+          session.SaveChanges()  → succeeds; Enum keys are serialized as their string values.
+        """
+        m = Machine(checks={CheckType.ENGINE: CheckStatus.GOOD, CheckType.GEARS: CheckStatus.GOOD})
+        with self.store.open_session() as session:
+            session.store(m, "machines/1")
+            session.save_changes()
+
+    def test_round_trip_preserves_enum_dict_values(self):
+        """
+        C# spec: after StoreOnDictionaryWithEnumKeyShouldWork, loading the document back
+        gives Checks[CheckType.Engine] == CheckStatus.Good.
+        """
+        m = Machine(checks={CheckType.ENGINE: CheckStatus.GOOD, CheckType.GEARS: CheckStatus.BAD})
+        with self.store.open_session() as session:
+            session.store(m, "machines/2")
+            session.save_changes()
+
+        with self.store.open_session() as session:
+            loaded = session.load("machines/2", Machine)
+            self.assertIsNotNone(loaded, "Document should be loadable after store")
+            # JSON deserializes back to string keys; verify the enum values were stored correctly.
+            self.assertEqual("Good", loaded.checks.get("Engine"), "Engine check should be Good")
+            self.assertEqual("Bad", loaded.checks.get("Gears"), "Gears check should be Bad")
+
+    # ------------------------------------------------------------------ #
+    #  Baseline: dict with string keys                                    #
+    # ------------------------------------------------------------------ #
+
+    def test_store_entity_with_string_keyed_dict_works(self):
+        """
+        Baseline: when dict keys are plain strings, store() works without error.
+        Confirms the serialization layer itself is functional.
+        """
+        m = Machine(checks={"Engine": "Good", "Gears": "Good"})
+        with self.store.open_session() as session:
+            session.store(m, "machines/3")
+            session.save_changes()
+
+        with self.store.open_session() as session:
+            loaded = session.load("machines/3", Machine)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(2, len(loaded.checks))

--- a/ravendb/tools/utils.py
+++ b/ravendb/tools/utils.py
@@ -942,7 +942,19 @@ class Utils(object):
 
     @staticmethod
     def entity_to_dict(entity, default_method) -> dict:
-        return json.loads(json.dumps(entity, default=default_method))
+        def _normalize_enum_keys(obj):
+            """Recursively convert Enum dict keys to their values so json.dumps accepts them."""
+            if isinstance(obj, dict):
+                return {(k.value if isinstance(k, Enum) else k): _normalize_enum_keys(v) for k, v in obj.items()}
+            if isinstance(obj, (list, set, tuple)):
+                return [_normalize_enum_keys(i) for i in obj]
+            return obj
+
+        def _normalized_default(o):
+            result = default_method(o)
+            return _normalize_enum_keys(result)
+
+        return json.loads(json.dumps(entity, default=_normalized_default))
 
     @staticmethod
     def add_hours(date: datetime, hours: int):


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1029
https://issues.hibernatingrhinos.com/issue/RDBC-1030

### Additional description

**RDBC-1029** – `BulkInsert._get_exception_from_operation` called the non-existent `str.starts_with` method (Python has `str.startswith`), raising `AttributeError` on any bulk-insert server error. Fixed the typo.

**RDBC-1030** – `Utils.entity_to_dict` passed a dict with `Enum` keys directly to `json.dumps`, which raises `TypeError` because `Enum` instances are not JSON-serialisable as keys. Fixed by recursively normalising `Enum` keys to their `.value` before serialisation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed