### PR TITLE
RDBC-1042 URL-decode Database-Missing header before raising DatabaseDoesNotExistException

### DIFF
--- a/ravendb/exceptions/exceptions.py
+++ b/ravendb/exceptions/exceptions.py
@@ -29,7 +29,7 @@ class ArgumentOutOfRangeException(Exception):
     pass
 
 
-class DatabaseDoesNotExistException(Exception):
+class DatabaseDoesNotExistException(RuntimeError):
     pass
 
 

--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, Future, FIRST_COMPLETED, wait, ALL_COMPLETED
+from urllib.parse import unquote
 import uuid
 from json import JSONDecodeError
 from threading import Timer, Semaphore, Lock
@@ -564,7 +565,7 @@ class RequestExecutor:
                     ):
                         db_missing_header = response.headers.get("Database-Missing", None)
                         if db_missing_header is not None:
-                            raise DatabaseDoesNotExistException(db_missing_header)
+                            raise DatabaseDoesNotExistException(unquote(db_missing_header))
                         self._throw_failed_to_contact_all_nodes(command, request)
                     return  # we either handled this already in the unsuccessful response or we are throwing
                 self._on_succeed_request_invoke(self._database_name, url, response, request, attempt_num)
@@ -1114,8 +1115,16 @@ class RequestExecutor:
             return True
         else:
             command.on_response_failure(response)
+            db_missing_header = response.headers.get("Database-Missing", None)
+            if db_missing_header is not None:
+                raise DatabaseDoesNotExistException(unquote(db_missing_header))
             try:  # todo: exception dispatcher
-                raise RuntimeError(json.loads(response.text).get("Message", "Missing message"))
+                data = json.loads(response.text)
+                err_type = data.get("Type", "")
+                message = data.get("Message", "Missing message")
+                if err_type.endswith("DatabaseDoesNotExistException"):
+                    raise DatabaseDoesNotExistException(message)
+                raise RuntimeError(message)
             except JSONDecodeError as e:
                 raise RuntimeError(f"Failed to parse response: {response.text}") from e
 

--- a/ravendb/tests/issue_tests/test_RDBC_1042.py
+++ b/ravendb/tests/issue_tests/test_RDBC_1042.py
@@ -1,0 +1,46 @@
+"""
+RDBC-1042: Database-Missing header is URL-decoded; raises DatabaseDoesNotExistException.
+
+C# reference: RavenDB-24435
+"""
+
+import unittest
+
+from ravendb.exceptions.exceptions import DatabaseDoesNotExistException
+from ravendb.tests.test_base import TestBase
+
+
+class TestUnicodeDatabaseExceptionUnit(unittest.TestCase):
+    """Unit tests that do not require a live server."""
+
+    def test_database_does_not_exist_exception_importable(self):
+        exc = DatabaseDoesNotExistException("my database")
+        self.assertIn("my database", str(exc))
+
+    def test_header_unquote_applied(self):
+        # Simulate the server-set header value (percent-encoded) being decoded
+        from urllib.parse import unquote
+
+        encoded = "my%20db%20with%20spaces"
+        exc = DatabaseDoesNotExistException(unquote(encoded))
+        self.assertIn("my db with spaces", str(exc))
+        self.assertNotIn("%20", str(exc))
+
+
+class TestUnicodeDatabaseExceptionIntegration(TestBase):
+    def test_missing_unicode_db_raises_correct_exception(self):
+        from ravendb.documents.store.definition import DocumentStore
+
+        base_urls = self.get_document_store().urls
+        with DocumentStore(base_urls, "my db with spaces") as store:
+            store.initialize()
+            with self.assertRaises(DatabaseDoesNotExistException) as ctx:
+                with store.open_session() as session:
+                    session.load("docs/1")
+            # Exception message should be decoded (no %20)
+            msg = str(ctx.exception)
+            self.assertNotIn("%20", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1042

### Additional description

**RDBC-1042** – When a request targets a database with special characters in its name (spaces, Unicode, etc.), the server sets the `Database-Missing` header using `Uri.EscapeDataString`, producing a percent-encoded value such as `my%20db`. The Python client was raising `DatabaseDoesNotExistException` with the raw encoded string, making the error message unreadable. Fixed by decoding the header value with `urllib.parse.unquote` before constructing the exception, matching C# `Uri.UnescapeDataString` behavior.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed