### PR TITLE
RDBC-1057 Metadata wasn't attached to compare exchange value via session API

### DIFF
--- a/ravendb/documents/operations/compare_exchange/compare_exchange.py
+++ b/ravendb/documents/operations/compare_exchange/compare_exchange.py
@@ -95,7 +95,10 @@ class CompareExchangeSessionValue(Generic[_T]):
                 else:
                     entity = self.__original_value.value
 
-                value = CompareExchangeValue(self._key, self._index, entity)
+                metadata = (
+                    self.__original_value.metadata if self.__original_value.has_metadata else None
+                )
+                value = CompareExchangeValue(self._key, self._index, entity, metadata)
                 self.__value = value
                 return value
 

--- a/ravendb/documents/operations/compare_exchange/compare_exchange.py
+++ b/ravendb/documents/operations/compare_exchange/compare_exchange.py
@@ -95,9 +95,7 @@ class CompareExchangeSessionValue(Generic[_T]):
                 else:
                     entity = self.__original_value.value
 
-                metadata = (
-                    self.__original_value.metadata if self.__original_value.has_metadata else None
-                )
+                metadata = self.__original_value.metadata if self.__original_value.has_metadata else None
                 value = CompareExchangeValue(self._key, self._index, entity, metadata)
                 self.__value = value
                 return value

--- a/ravendb/tests/issue_tests/test_compare_exchange_session_api.py
+++ b/ravendb/tests/issue_tests/test_compare_exchange_session_api.py
@@ -11,9 +11,7 @@ class TestCompareExchangeSessionApi(TestBase):
         options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
 
         with self.store.open_session(session_options=options) as session:
-            value = session.advanced.cluster_transaction.create_compare_exchange_value(
-                key, User(name="Simon")
-            )
+            value = session.advanced.cluster_transaction.create_compare_exchange_value(key, User(name="Simon"))
             value.metadata["@expires"] = "2099-01-01T00:00:00.0000000Z"
             value.metadata["@created-at"] = "2026-04-15T12:27:51.556568Z"
             value.metadata["Custom-Tag"] = "hello"
@@ -34,9 +32,7 @@ class TestCompareExchangeSessionApi(TestBase):
         options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
 
         with self.store.open_session(session_options=options) as session:
-            session.advanced.cluster_transaction.create_compare_exchange_value(
-                key, User(name="Simon")
-            )
+            session.advanced.cluster_transaction.create_compare_exchange_value(key, User(name="Simon"))
             session.save_changes()
 
         with self.store.open_session(session_options=options) as session:
@@ -55,18 +51,14 @@ class TestCompareExchangeSessionApi(TestBase):
         options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
 
         with self.store.open_session(session_options=options) as session:
-            session.advanced.cluster_transaction.create_compare_exchange_value(
-                key, User(name="Simon")
-            )
+            session.advanced.cluster_transaction.create_compare_exchange_value(key, User(name="Simon"))
             session.save_changes()
 
         with self.store.open_session(session_options=options) as session:
             current = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
             self.assertIsNotNone(current)
 
-            session.advanced.cluster_transaction.delete_compare_exchange_value(
-                current.key, current.index
-            )
+            session.advanced.cluster_transaction.delete_compare_exchange_value(current.key, current.index)
             session.save_changes()
 
         with self.store.open_session(session_options=options) as session:

--- a/ravendb/tests/issue_tests/test_compare_exchange_session_api.py
+++ b/ravendb/tests/issue_tests/test_compare_exchange_session_api.py
@@ -1,0 +1,74 @@
+from ravendb import SessionOptions, TransactionMode
+from ravendb.tests.test_base import TestBase, User
+
+
+class TestCompareExchangeSessionApi(TestBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_compare_exchange_value_returns_metadata(self):
+        key = "locks/happy-metadata"
+        options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+
+        with self.store.open_session(session_options=options) as session:
+            value = session.advanced.cluster_transaction.create_compare_exchange_value(
+                key, User(name="Simon")
+            )
+            value.metadata["@expires"] = "2099-01-01T00:00:00.0000000Z"
+            value.metadata["@created-at"] = "2026-04-15T12:27:51.556568Z"
+            value.metadata["Custom-Tag"] = "hello"
+            session.save_changes()
+
+        with self.store.open_session(session_options=options) as session:
+            got = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
+
+            self.assertIsNotNone(got)
+            self.assertEqual("Simon", got.value.name)
+            self.assertTrue(got.has_metadata)
+            self.assertEqual("2099-01-01T00:00:00.0000000Z", got.metadata["@expires"])
+            self.assertEqual("2026-04-15T12:27:51.556568Z", got.metadata["@created-at"])
+            self.assertEqual("hello", got.metadata["Custom-Tag"])
+
+    def test_delete_compare_exchange_value_removes_item(self):
+        key = "locks/happy-delete"
+        options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+
+        with self.store.open_session(session_options=options) as session:
+            session.advanced.cluster_transaction.create_compare_exchange_value(
+                key, User(name="Simon")
+            )
+            session.save_changes()
+
+        with self.store.open_session(session_options=options) as session:
+            current = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
+            self.assertIsNotNone(current)
+
+            session.advanced.cluster_transaction.delete_compare_exchange_value(current)
+            session.save_changes()
+
+        with self.store.open_session(session_options=options) as session:
+            after = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
+            self.assertIsNone(after)
+
+    def test_delete_compare_exchange_value_by_key_and_index_removes_item(self):
+        key = "locks/happy-delete-by-key"
+        options = SessionOptions(transaction_mode=TransactionMode.CLUSTER_WIDE)
+
+        with self.store.open_session(session_options=options) as session:
+            session.advanced.cluster_transaction.create_compare_exchange_value(
+                key, User(name="Simon")
+            )
+            session.save_changes()
+
+        with self.store.open_session(session_options=options) as session:
+            current = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
+            self.assertIsNotNone(current)
+
+            session.advanced.cluster_transaction.delete_compare_exchange_value(
+                current.key, current.index
+            )
+            session.save_changes()
+
+        with self.store.open_session(session_options=options) as session:
+            after = session.advanced.cluster_transaction.get_compare_exchange_value(key, User)
+            self.assertIsNone(after)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.2.1",
+    version="7.2.1.post1",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
### Issue link

[RDBC-1057](https://issues.hibernatingrhinos.com/issue/RDBC-1057) Issues with Compare Exchange API

### Additional description

Fixes a bug with the compare exchange session API, adds a test that proves the fix works. Also adds 2 tests confirming that the compare exchange delete works properly.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Python Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- x ] Tests have been added that prove the fix is effective or that the feature works
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No
