### PR TITLE
RDBC-1068 Bump CLIENT_VERSION to 7.2.3

### DIFF
--- a/ravendb/http/request_executor.py
+++ b/ravendb/http/request_executor.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 class RequestExecutor:
     __INITIAL_TOPOLOGY_ETAG = -2
     __GLOBAL_APPLICATION_IDENTIFIER = uuid.uuid4()
-    CLIENT_VERSION = "7.2.2"
+    CLIENT_VERSION = "7.2.3"
     logger = logging.getLogger("request_executor")
 
     # todo: initializer should take also cryptography certificates


### PR DESCRIPTION
The 7.2.3 version bump (#295, c3ca81d) updated `setup.py` but missed `RequestExecutor.CLIENT_VERSION`, which was left at `7.2.2`. Without this, the published 7.2.3 client reports itself to the server as 7.2.2.

This bumps `CLIENT_VERSION` to `7.2.3` to match. Required before publishing ravendb 7.2.3 to PyPI.