### PR TITLE
RavenDB-26793 Time-series bulk-insert UTC fix + custom-entity-name control-char guard

### DIFF
--- a/ravendb/tests/jvm_migrated_tests/client_tests/test_custom_entity_name.py
+++ b/ravendb/tests/jvm_migrated_tests/client_tests/test_custom_entity_name.py
@@ -100,7 +100,9 @@ class TestCustomEntityName(TestBase):
         )
 
     def __test_when_collection_and_id_contain_special_chars(self, c: str) -> None:
-        if 14 <= ord(c) <= 31:
+        # RavenDB now rejects control characters in document ids (including the generated HiLo id),
+        # so skip the whole C0 control range rather than only 14..31.
+        if ord(c) <= 31:
             return
 
         self.c = c

--- a/ravendb/tools/utils.py
+++ b/ravendb/tools/utils.py
@@ -15,7 +15,7 @@ except ImportError:
     from collections import Iterable, Sequence
 
 from ravendb.tools.projection import create_entity_with_mapper
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from threading import Timer
 from copy import deepcopy
@@ -958,4 +958,8 @@ class Utils(object):
 
     @staticmethod
     def get_unix_time_in_ms(date: datetime) -> int:
+        # Naive datetimes are treated as UTC (consistent with Utils.datetime_to_string) so that
+        # bulk-insert time-series timestamps are not shifted by the machine's local UTC offset.
+        if date.tzinfo is None:
+            date = date.replace(tzinfo=timezone.utc)
         return int(date.timestamp() * 1000)


### PR DESCRIPTION
Two client-side fixes surfaced while validating the 6.2.18 / 7.2.5 nightlies against the Python client.

### 1. Bulk-insert time-series timestamps shifted by local UTC offset (bug)
`Utils.get_unix_time_in_ms()` used `datetime.timestamp()`, which interprets a **naive** datetime in the machine's local timezone. Bulk-insert time-series timestamps were therefore shifted by the local UTC offset on non-UTC machines (e.g. +2h on CET), whereas the regular session path (`Utils.datetime_to_string`) treats naive datetimes as UTC. That made ~18 `test_time_series_bulk_insert` / `test_typed_bulk_insert` cases fail locally (they pass on CI because CI runs in UTC).

Fix: treat naive datetimes as UTC in `get_unix_time_in_ms` (its only caller is the bulk-insert time-series path), consistent with `datetime_to_string`. tz-aware datetimes are unaffected.

### 2. `test_custom_entity_name` guard let control chars through (test)
Current 6.2.x / 7.2.x servers now **reject control characters in document ids** (including the generated `Raven/Hilo/...` id) via `DocumentIdWorker.ThrowIdentifierWithControlCharacters`. Verified locally: bundled 7.2.1 accepts them (test passes), while both 6.2.18-nightly and 7.2.5-nightly reject them (HTTP 500). The test injected control chars 1..13 into the collection name through a guard that only skipped 14..31; widened it to skip the whole C0 control range (`ord(c) <= 31`).

### Verification
- `black --check` clean.
- The 26 previously-failing cases (18 bulk-insert TS + typed bulk-insert + `test_custom_entity_name`) pass against a local 7.2.5-nightly server.

### Notes for reviewers
- `test_custom_entity_name` is a jvm-migrated test; the `14 <= c <= 31` guard is a straight port, so the JVM / C# / Node suites likely carry the same guard and will start failing against these nightlies — worth fixing across clients or documenting the id contract.
- The server returns **HTTP 500** for a control-char id (client-invalid input); arguably it should be a `4xx`. That's a separate server-side consideration, not addressed here.
