### PR TITLE
RDBC-1104 Bump version to 7.2.3.post2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="ravendb",
     packages=find_packages(exclude=["*.tests.*", "tests", "*.tests", "tests.*"]),
-    version="7.2.3.post1",
+    version="7.2.3.post2",
     long_description_content_type="text/markdown",
     long_description=open("README_pypi.md").read(),
     description="Python client for RavenDB NoSQL Database",


### PR DESCRIPTION
### Issue

https://issues.hibernatingrhinos.com/issue/RDBC-1104

### What changed

Version bump to `7.2.3.post2` for the post-release that ships the bulk insert performance work (#306), the bulk-insert time series UTC fix (#303) and the on-disk topology cache plus the 7.x logging schema rewrite (#304).

`CLIENT_VERSION` stays `7.2.3` per the post-release convention.

### Checklist

- [x] Tests added or existing tests cover the change
- [ ] Breaking change (explain above if checked)
